### PR TITLE
Add option to prevent auto-updating when editing a different file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # MJML
 
-This is a fork of original @attilabuti VSC extension : (https://github.com/attilabuti/vscode-mjml)[https://github.com/attilabuti/vscode-mjml]
+This is a fork of the [@mjmlio extension](https://github.com/mjmlio/vscode-mjml), which itself, is a fork of [the original @attilabuti VSC extension.](https://github.com/attilabuti/vscode-mjml)
+
+## Differences
+
+-   `mjml.updateOnSeparateFileChange`: optionally restrict preview to original file used to open it.
+
+---
 
 MJML preview, lint, compile for Visual Studio Code.
 
 ## Features
 
-* Live preview for MJML files. Preview updates as you type. Preview based on [html-preview-vscode](https://github.com/tht13/html-preview-vscode).
-* Inline errors (squiggle underlines). Linter based on [atom-linter-mjml](https://github.com/mjmlio/atom-linter-mjml).
-* Export HTML file from MJML.
-* Copy the result HTML to clipboard.
-* Take a screenshot of the rendered MJML document.
-* Send email with Nodemailer or Mailjet.
-* Code snippets for MJML. Based on [mjml-syntax](https://github.com/mjmlio/mjml-syntax).
-* Fetch official templates. Based on [mjml-app](https://github.com/mjmlio/mjml-app).
-* Beautify MJML code.
-* Migrate a template from MJML 3 to MJML 4.
-* MJML syntax highlight. Based on [mjml-syntax](https://github.com/mjmlio/mjml-syntax).
-* Built-in MJML documentation with `Try it live` support.
+-   Live preview for MJML files. Preview updates as you type. Preview based on [html-preview-vscode](https://github.com/tht13/html-preview-vscode).
+-   Inline errors (squiggle underlines). Linter based on [atom-linter-mjml](https://github.com/mjmlio/atom-linter-mjml).
+-   Export HTML file from MJML.
+-   Copy the result HTML to clipboard.
+-   Take a screenshot of the rendered MJML document.
+-   Send email with Nodemailer or Mailjet.
+-   Code snippets for MJML. Based on [mjml-syntax](https://github.com/mjmlio/mjml-syntax).
+-   Fetch official templates. Based on [mjml-app](https://github.com/mjmlio/mjml-app).
+-   Beautify MJML code.
+-   Migrate a template from MJML 3 to MJML 4.
+-   MJML syntax highlight. Based on [mjml-syntax](https://github.com/mjmlio/mjml-syntax).
+-   Built-in MJML documentation with `Try it live` support.
 
 ## It looks like this
 
@@ -36,94 +42,97 @@ Start command palette (with `Ctrl+Shift+P` or `F1`) and start typing `MJML`.
 ## Available commands
 
 The following command is available:
-* **MJML: Beautify** or **Format Document** Beautify MJML code.
-* **MJML: Copy HTML** Copy the result HTML to clipboard.
-* **MJML: Export HTML** Export HTML file from MJML.
-* **MJML: Migrate** Migrate a template from MJML 3 to MJML 4.
-* **MJML: Multiple Screenshots** Take multiple screenshots of the rendered MJML document.
-* **MJML: Open Preview to the Side** Opens a preview in a column alongside the current document.
-* **MJML: Screenshot** Take a screenshot of the rendered MJML document, and save it as a file.
-* **MJML: Send Email** Send email with Nodemailer or Mailjet.
-* **MJML: Template** Fetch official templates.
-* **MJML: Documentation** open the MJML documentation.
-* **MJML: Search in MJML documentation** search for the selected mj-element in the MJML documentation.
-* **MJML: Version** Shows the version of MJML.
+
+-   **MJML: Beautify** or **Format Document** Beautify MJML code.
+-   **MJML: Copy HTML** Copy the result HTML to clipboard.
+-   **MJML: Export HTML** Export HTML file from MJML.
+-   **MJML: Migrate** Migrate a template from MJML 3 to MJML 4.
+-   **MJML: Multiple Screenshots** Take multiple screenshots of the rendered MJML document.
+-   **MJML: Open Preview to the Side** Opens a preview in a column alongside the current document.
+-   **MJML: Screenshot** Take a screenshot of the rendered MJML document, and save it as a file.
+-   **MJML: Send Email** Send email with Nodemailer or Mailjet.
+-   **MJML: Template** Fetch official templates.
+-   **MJML: Documentation** open the MJML documentation.
+-   **MJML: Search in MJML documentation** search for the selected mj-element in the MJML documentation.
+-   **MJML: Version** Shows the version of MJML.
 
 ## Settings
 
-| Name | Default | Description |
-| --- | --- | --- |
-| `mjml.autoPreview` | `false` | Automatically update preview when switching between MJML documents. |
-| `mjml.beautifyHtmlOutput` | `false` | Beautify HTML output. (Works when `mjml.minifyHtmlOutput` aren't enabled.) |
-| `mjml.beautify` | ` ` | Beautify options ([available options](https://github.com/beautify-web/js-beautify#options)). |
-| `mjml.exportType` | `.html` | Specifies the file type of the output file. |
-| `mjml.lintEnable` | `true` | Enable/disable MJML linter (requires restart). |
-| `mjml.lintWhenTyping` | `true` | Whether the linter is run on type or on save. |
-| `mjml.mailFromName` | ` ` | Sender name. |
-| `mjml.mailRecipients` | ` ` | Comma separated list of recipients email addresses. |
-| `mjml.mailSender` | ` ` | Sender email address. (Mailjet: must be a verified sender.) |
-| `mjml.mailSubject` | ` ` | Email subject. |
-| `mjml.mailer` | `mailjet` | Send email with Nodemailer or Mailjet. Possible values are 'nodemailer' and 'mailjet'. |
-| `mjml.mailjetAPIKey` | ` ` | Mailjet API Key. |
-| `mjml.mailjetAPISecret` | ` ` | Mailjet API Secret. |
-| `mjml.minifyHtmlOutput` | `true` | Minify HTML output. |
-| `mjml.nodemailer` | `{}` | Nodemailer configuration. Please see the [Nodemailer](https://nodemailer.com) documentation for more information. |
-| `mjml.preserveFocus` | `true` | Preserve focus of Text Editor after preview open. |
-| `mjml.screenshotQuality` | `75` | Screenshot quality. |
-| `mjml.screenshotType` | `jpg` | Screenshot type. Possible values are 'png', 'jpg', and 'jpeg'. |
-| `mjml.screenshotWidth` | `650` | Screenshot width. |
-| `mjml.screenshotWidths` | `640,750` | Screenshot widths. |
-| `mjml.updateWhenTyping` | `true` | Update preview when typing. |
-| `mjml.previewBackgroundColor` | ` ` | Preview background color. |
-| `mjml.autoClosePreview` | `true` | Automatically close preview when all open MJML documents have been closed. |
-| `mjml.showSaveDialog` | `false` | Show the save as dialog instead of input box. |
-| `mjml.templateGallery` | `false` | Show the template gallery instead of quick pick. |
-| `mjml.templateGalleryAutoClose` | `true` | Automatically close template gallery when selecting a template. |
+| Name                              | Default   | Description                                                                                                       |
+| --------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
+| `mjml.autoPreview`                | `false`   | Automatically update preview when switching between MJML documents.                                               |
+| `mjml.beautifyHtmlOutput`         | `false`   | Beautify HTML output. (Works when `mjml.minifyHtmlOutput` aren't enabled.)                                        |
+| `mjml.beautify`                   | ` `       | Beautify options ([available options](https://github.com/beautify-web/js-beautify#options)).                      |
+| `mjml.exportType`                 | `.html`   | Specifies the file type of the output file.                                                                       |
+| `mjml.lintEnable`                 | `true`    | Enable/disable MJML linter (requires restart).                                                                    |
+| `mjml.lintWhenTyping`             | `true`    | Whether the linter is run on type or on save.                                                                     |
+| `mjml.mailFromName`               | ` `       | Sender name.                                                                                                      |
+| `mjml.mailRecipients`             | ` `       | Comma separated list of recipients email addresses.                                                               |
+| `mjml.mailSender`                 | ` `       | Sender email address. (Mailjet: must be a verified sender.)                                                       |
+| `mjml.mailSubject`                | ` `       | Email subject.                                                                                                    |
+| `mjml.mailer`                     | `mailjet` | Send email with Nodemailer or Mailjet. Possible values are 'nodemailer' and 'mailjet'.                            |
+| `mjml.mailjetAPIKey`              | ` `       | Mailjet API Key.                                                                                                  |
+| `mjml.mailjetAPISecret`           | ` `       | Mailjet API Secret.                                                                                               |
+| `mjml.minifyHtmlOutput`           | `true`    | Minify HTML output.                                                                                               |
+| `mjml.nodemailer`                 | `{}`      | Nodemailer configuration. Please see the [Nodemailer](https://nodemailer.com) documentation for more information. |
+| `mjml.preserveFocus`              | `true`    | Preserve focus of Text Editor after preview open.                                                                 |
+| `mjml.screenshotQuality`          | `75`      | Screenshot quality.                                                                                               |
+| `mjml.screenshotType`             | `jpg`     | Screenshot type. Possible values are 'png', 'jpg', and 'jpeg'.                                                    |
+| `mjml.screenshotWidth`            | `650`     | Screenshot width.                                                                                                 |
+| `mjml.screenshotWidths`           | `640,750` | Screenshot widths.                                                                                                |
+| `mjml.updateWhenTyping`           | `true`    | Update preview when typing.                                                                                       |
+| `mjml.previewBackgroundColor`     | ` `       | Preview background color.                                                                                         |
+| `mjml.autoClosePreview`           | `true`    | Automatically close preview when all open MJML documents have been closed.                                        |
+| `mjml.showSaveDialog`             | `false`   | Show the save as dialog instead of input box.                                                                     |
+| `mjml.templateGallery`            | `false`   | Show the template gallery instead of quick pick.                                                                  |
+| `mjml.templateGalleryAutoClose`   | `true`    | Automatically close template gallery when selecting a template.                                                   |
+| `mjml.updateOnSeparateFileChange` | `true`    | Automatically update preview when editing a different file.                                                       |
 
 ## Snippets
 
-| Trigger | URL | Content |
-| --- | --- | --- |
-| `mjall` | [mj-all](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-attributes/README.md) | `<mj-all />` |
-| `mjattributes` | [mj-attributes](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-attributes/README.md) | `<mj-attributes></mj-attributes>` |
-| `mjbody` | [mj-body](https://github.com/mjmlio/mjml/blob/master/packages/mjml-body/README.md) | `<mj-body></mj-body>` |
-| `mjbreakpoint` | [mj-breakpoint](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-breakpoint/README.md) | `<mj-breakpoint width="" />` |
-| `mjbutton` | [mj-button](https://github.com/mjmlio/mjml/blob/master/packages/mjml-button/README.md) | `<mj-button></mj-button>` |
-| `mjcarousel` | [mj-carousel](https://github.com/mjmlio/mjml/blob/master/packages/mjml-carousel/README.md) | `<mj-carousel></mj-carousel>` |
-| `mjcarousel-image` | [mj-carousel-image](https://github.com/mjmlio/mjml/blob/master/packages/mjml-carousel/README.md#mjml-carousel-image) | `<mj-carousel-image src="" />` |
-| `mjclass` | [mj-class](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-attributes/README.md) | `<mj-class name="" />` |
-| `mjcolumn` | [mj-column](https://github.com/mjmlio/mjml/blob/master/packages/mjml-column/README.md) | `<mj-column width=""></mj-column>` |
-| `mjdivider` | [mj-divider](https://github.com/mjmlio/mjml/blob/master/packages/mjml-divider/README.md) | `<mj-divider />` |
-| `mjfont` | [mj-font](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-font/README.md) | `<mj-font name="" href="" />` |
-| `mjgroup` | [mj-group](https://github.com/mjmlio/mjml/blob/master/packages/mjml-group/README.md) | `<mj-group></mj-group>` |
-| `mjhead` | [mj-head](https://github.com/mjmlio/mjml/blob/master/doc/guide.md#mj-head) | `<mj-head></mj-head>` |
-| `mjhero` | [mj-hero](https://github.com/mjmlio/mjml/blob/master/packages/mjml-hero/README.md) | `<mj-hero></mj-hero>` |
-| `mjimage` | [mj-image](https://github.com/mjmlio/mjml/blob/master/packages/mjml-image/README.md) | `<mj-image src="" alt="" />` |
-| `mjinclude` | [mj-include](https://github.com/mjmlio/mjml/blob/master/doc/guide.md#mj-include) | `<mj-include path="" />` |
-| `mjraw` | [mj-raw](https://github.com/mjmlio/mjml/blob/master/packages/mjml-raw/README.md) | `<mj-raw></mj-raw>` |
-| `mjsection` | [mj-section](https://github.com/mjmlio/mjml/blob/master/packages/mjml-section/README.md) | `<mj-section></mj-section>` |
-| `mjsocial` | [mj-social](https://github.com/mjmlio/mjml/blob/master/packages/mjml-social/README.md) | `<mj-social></mj-social>` |
-| `mjsocialelement` | [mj-social-element](https://github.com/mjmlio/mjml/blob/master/packages/mjml-social/README.md#mj-social-element) | `<mj-social-element></mj-social-element>` |
-| `mjstyle` | [mj-style](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-style/README.md) | `<mj-style></mj-style>` |
-| `mjtable` | [mj-table](https://github.com/mjmlio/mjml/blob/master/packages/mjml-table/README.md) | `<mj-table></mj-table>` |
-| `mjtext` | [mj-text](https://github.com/mjmlio/mjml/blob/master/packages/mjml-text/README.md) | `<mj-text></mj-text>` |
-| `mjtitle` | [mj-title](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-title/README.md) | `<mj-title></mj-title>` |
-| `mjml` | [mjml](https://github.com/mjmlio/mjml/blob/master/doc/guide.md#mjml) | `<mjml></mjml>` |
-| `mjpreview` | [mj-preview](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-preview/README.md) | `<mj-preview></mj-preview>` |
-| `mjspacer` | [mj-spacer](https://github.com/mjmlio/mjml/blob/master/packages/mjml-spacer/README.md) | `<mj-spacer height="" />` |
-| `mjwrapper` | [mj-wrapper](https://github.com/mjmlio/mjml/blob/master/packages/mjml-wrapper/README.md) | `<mj-wrapper></mj-wrapper>` |
-| `mjaccordion` | [mj-accordion](https://github.com/mjmlio/mjml/blob/master/packages/mjml-accordion/README.md) | `<mj-accordion></mj-accordion>` |
+| Trigger               | URL                                                                                                                         | Content                                            |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `mjall`               | [mj-all](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-attributes/README.md)                                | `<mj-all />`                                       |
+| `mjattributes`        | [mj-attributes](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-attributes/README.md)                         | `<mj-attributes></mj-attributes>`                  |
+| `mjbody`              | [mj-body](https://github.com/mjmlio/mjml/blob/master/packages/mjml-body/README.md)                                          | `<mj-body></mj-body>`                              |
+| `mjbreakpoint`        | [mj-breakpoint](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-breakpoint/README.md)                         | `<mj-breakpoint width="" />`                       |
+| `mjbutton`            | [mj-button](https://github.com/mjmlio/mjml/blob/master/packages/mjml-button/README.md)                                      | `<mj-button></mj-button>`                          |
+| `mjcarousel`          | [mj-carousel](https://github.com/mjmlio/mjml/blob/master/packages/mjml-carousel/README.md)                                  | `<mj-carousel></mj-carousel>`                      |
+| `mjcarousel-image`    | [mj-carousel-image](https://github.com/mjmlio/mjml/blob/master/packages/mjml-carousel/README.md#mjml-carousel-image)        | `<mj-carousel-image src="" />`                     |
+| `mjclass`             | [mj-class](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-attributes/README.md)                              | `<mj-class name="" />`                             |
+| `mjcolumn`            | [mj-column](https://github.com/mjmlio/mjml/blob/master/packages/mjml-column/README.md)                                      | `<mj-column width=""></mj-column>`                 |
+| `mjdivider`           | [mj-divider](https://github.com/mjmlio/mjml/blob/master/packages/mjml-divider/README.md)                                    | `<mj-divider />`                                   |
+| `mjfont`              | [mj-font](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-font/README.md)                                     | `<mj-font name="" href="" />`                      |
+| `mjgroup`             | [mj-group](https://github.com/mjmlio/mjml/blob/master/packages/mjml-group/README.md)                                        | `<mj-group></mj-group>`                            |
+| `mjhead`              | [mj-head](https://github.com/mjmlio/mjml/blob/master/doc/guide.md#mj-head)                                                  | `<mj-head></mj-head>`                              |
+| `mjhero`              | [mj-hero](https://github.com/mjmlio/mjml/blob/master/packages/mjml-hero/README.md)                                          | `<mj-hero></mj-hero>`                              |
+| `mjimage`             | [mj-image](https://github.com/mjmlio/mjml/blob/master/packages/mjml-image/README.md)                                        | `<mj-image src="" alt="" />`                       |
+| `mjinclude`           | [mj-include](https://github.com/mjmlio/mjml/blob/master/doc/guide.md#mj-include)                                            | `<mj-include path="" />`                           |
+| `mjraw`               | [mj-raw](https://github.com/mjmlio/mjml/blob/master/packages/mjml-raw/README.md)                                            | `<mj-raw></mj-raw>`                                |
+| `mjsection`           | [mj-section](https://github.com/mjmlio/mjml/blob/master/packages/mjml-section/README.md)                                    | `<mj-section></mj-section>`                        |
+| `mjsocial`            | [mj-social](https://github.com/mjmlio/mjml/blob/master/packages/mjml-social/README.md)                                      | `<mj-social></mj-social>`                          |
+| `mjsocialelement`     | [mj-social-element](https://github.com/mjmlio/mjml/blob/master/packages/mjml-social/README.md#mj-social-element)            | `<mj-social-element></mj-social-element>`          |
+| `mjstyle`             | [mj-style](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-style/README.md)                                   | `<mj-style></mj-style>`                            |
+| `mjtable`             | [mj-table](https://github.com/mjmlio/mjml/blob/master/packages/mjml-table/README.md)                                        | `<mj-table></mj-table>`                            |
+| `mjtext`              | [mj-text](https://github.com/mjmlio/mjml/blob/master/packages/mjml-text/README.md)                                          | `<mj-text></mj-text>`                              |
+| `mjtitle`             | [mj-title](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-title/README.md)                                   | `<mj-title></mj-title>`                            |
+| `mjml`                | [mjml](https://github.com/mjmlio/mjml/blob/master/doc/guide.md#mjml)                                                        | `<mjml></mjml>`                                    |
+| `mjpreview`           | [mj-preview](https://github.com/mjmlio/mjml/blob/master/packages/mjml-head-preview/README.md)                               | `<mj-preview></mj-preview>`                        |
+| `mjspacer`            | [mj-spacer](https://github.com/mjmlio/mjml/blob/master/packages/mjml-spacer/README.md)                                      | `<mj-spacer height="" />`                          |
+| `mjwrapper`           | [mj-wrapper](https://github.com/mjmlio/mjml/blob/master/packages/mjml-wrapper/README.md)                                    | `<mj-wrapper></mj-wrapper>`                        |
+| `mjaccordion`         | [mj-accordion](https://github.com/mjmlio/mjml/blob/master/packages/mjml-accordion/README.md)                                | `<mj-accordion></mj-accordion>`                    |
 | `mjaccordion-element` | [mj-accordion-element](https://github.com/mjmlio/mjml/blob/master/packages/mjml-accordion/README.md#mjml-accordion-element) | `<mj-accordion-element>...</mj-accordion-element>` |
-| `mjnavbar` | [mj-navbar](https://github.com/mjmlio/mjml/blob/master/packages/mjml-navbar/README.md) | `<mj-navbar></mj-navbar>` |
-| `mjnavbarlink` | [mj-navbar-link](https://github.com/mjmlio/mjml/blob/master/packages/mjml-navbar/README.md#mjml-navbar-link) | `<mj-navbar-link></mj-navbar-link>` |
-| `mjlink` | [mj-link](https://mjml.io/documentation/#mjml-navbar) | `<mj-link href=""></mj-link>` |
-| `mjml-` | | Basic MJML Template |
+| `mjnavbar`            | [mj-navbar](https://github.com/mjmlio/mjml/blob/master/packages/mjml-navbar/README.md)                                      | `<mj-navbar></mj-navbar>`                          |
+| `mjnavbarlink`        | [mj-navbar-link](https://github.com/mjmlio/mjml/blob/master/packages/mjml-navbar/README.md#mjml-navbar-link)                | `<mj-navbar-link></mj-navbar-link>`                |
+| `mjlink`              | [mj-link](https://mjml.io/documentation/#mjml-navbar)                                                                       | `<mj-link href=""></mj-link>`                      |
+| `mjml-`               |                                                                                                                             | Basic MJML Template                                |
 
 ## Nodemailer configuration
 
 Please see the [Nodemailer](https://nodemailer.com) documentation for more information.
 
 ### [Gmail](https://gmail.com)
+
 ```json
 "mjml.nodemailer": {
     "service": "Gmail",
@@ -135,6 +144,7 @@ Please see the [Nodemailer](https://nodemailer.com) documentation for more infor
 ```
 
 ### [Mailtrap](https://mailtrap.io)
+
 ```json
 "mjml.nodemailer": {
     "host": "smtp.mailtrap.io",
@@ -147,6 +157,7 @@ Please see the [Nodemailer](https://nodemailer.com) documentation for more infor
 ```
 
 ### [Ethereal](https://ethereal.email)
+
 ```json
 "mjml.nodemailer": {
     "host": "smtp.ethereal.email",
@@ -161,16 +172,17 @@ Please see the [Nodemailer](https://nodemailer.com) documentation for more infor
 ## Change Log
 
 ### [1.0.0] (2019-11-20)
-* This is the initial release of this extension.
-* Update MJML to 4.5.1
+
+-   This is the initial release of this extension.
+-   Update MJML to 4.5.1
 
 ## Issues
 
-Submit the [issues](https://github.com/attilabuti/vscode-mjml/issues) if you find any bug or have any suggestion.
+Submit the [issues](https://github.com/Daniel-Knights/vscode-mjml/issues) if you find any bug or have any suggestion.
 
 ## Contribution
 
-Fork the [repo](https://github.com/attilabuti/vscode-mjml) and submit pull requests.
+Fork the [repo](https://github.com/Daniel-Knights/vscode-mjml) and submit pull requests.
 
 ## Contributors
 
@@ -178,9 +190,9 @@ Main Author: Attila Buti ([@attilabuti](https://github.com/attilabuti))
 
 A big thanks to the people that have contributed to this project:
 
-- Christian Brevik ([@cbrevik](https://github.com/cbrevik)) - [contributions](https://github.com/attilabuti/vscode-mjml/commits?author=cbrevik))
-- Kevin Oliveira ([@kvnol](https://github.com/kvnol)) - [contributions](https://github.com/attilabuti/vscode-mjml/commits?author=kvnol))
-- Joshua Skrzypek ([@jskrzypek](https://github.com/jskrzypek)) - [contributions](https://github.com/attilabuti/vscode-mjml/commits?author=jskrzypek))
+-   Christian Brevik ([@cbrevik](https://github.com/cbrevik)) - [contributions](https://github.com/attilabuti/vscode-mjml/commits?author=cbrevik))
+-   Kevin Oliveira ([@kvnol](https://github.com/kvnol)) - [contributions](https://github.com/attilabuti/vscode-mjml/commits?author=kvnol))
+-   Joshua Skrzypek ([@jskrzypek](https://github.com/jskrzypek)) - [contributions](https://github.com/attilabuti/vscode-mjml/commits?author=jskrzypek))
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,8501 @@
 {
     "name": "vscode-mjml",
-    "version": "1.0.3",
-    "lockfileVersion": 1,
+    "version": "1.0.4",
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "version": "1.0.4",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "copy-paste": "^1.3.0",
+                "js-beautify": "^1.8.8",
+                "mime": "^2.3.1",
+                "mjml": "^4.8.0",
+                "node-fetch": "^2.2.0",
+                "node-mailjet": "^3.3.1",
+                "nodemailer": "^4.6.8",
+                "npm": "^6.4.1",
+                "phantom": "^6.3.0"
+            },
+            "devDependencies": {
+                "@types/copy-paste": "^1.1.30",
+                "@types/file-url": "^2.0.0",
+                "@types/js-beautify": "^1.8.0",
+                "@types/mime": "^2.0.0",
+                "@types/node": "*",
+                "@types/node-fetch": "^2.1.2",
+                "@types/nodemailer": "^4.6.5",
+                "@types/npm": "^2.0.29",
+                "highlight.js": "^9.13.1",
+                "markdown-it": "^8.4.2",
+                "markdown-it-anchor": "^5.0.2",
+                "typescript": "^3.1.3",
+                "vscode": "^1.1.21"
+            },
+            "engines": {
+                "vscode": "^1.23.0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.12.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+            "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "node_modules/@types/copy-paste": {
+            "version": "1.1.30",
+            "resolved": "https://registry.npmjs.org/@types/copy-paste/-/copy-paste-1.1.30.tgz",
+            "integrity": "sha1-p9RUyeHkVCMo9/Huz1Mzvoz7UO0=",
+            "dev": true
+        },
+        "node_modules/@types/file-url": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/file-url/-/file-url-2.0.0.tgz",
+            "integrity": "sha512-9YqUM3izkmwtCbq6ANdcHJiU2mpDvPm3WuHOcJ5ZouHw7CoYcyY/KvZm6dmYTIurfrRsmBIvHr6y1jpBjDd4Jg==",
+            "dev": true
+        },
+        "node_modules/@types/js-beautify": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@types/js-beautify/-/js-beautify-1.8.1.tgz",
+            "integrity": "sha512-B1Br8yE27obcYvFx5ECZswT/947aAFNb9lHqnkUOhtOfvJqaa6Axibo4T+5G6iQlUfjgSd8am9R/9j9UBfRlrw==",
+            "dev": true
+        },
+        "node_modules/@types/mime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+            "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+            "dev": true
+        },
+        "node_modules/@types/node": {
+            "version": "12.7.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
+            "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw=="
+        },
+        "node_modules/@types/node-fetch": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
+            "integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/nodemailer": {
+            "version": "4.6.8",
+            "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-4.6.8.tgz",
+            "integrity": "sha512-IX1P3bxDP1VIdZf6/kIWYNmSejkYm9MOyMEtoDFi4DVzKjJ3kY4GhOcOAKs6lZRjqVVmF9UjPOZXuQczlpZThw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/npm": {
+            "version": "2.0.31",
+            "resolved": "https://registry.npmjs.org/@types/npm/-/npm-2.0.31.tgz",
+            "integrity": "sha512-v4JpUx83wVGItleYsnYeZrM8NTLSnYDfTE/iGm4owy6zZPNFNmnsvvrxiYtG3cVHt/XutzTjUBQ9Bh8bnvEkCw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+        },
+        "node_modules/agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "dependencies": {
+                "es6-promisify": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+            "dependencies": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "node_modules/ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ansi-styles/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+            "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dependencies": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "node_modules/assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/ast-types": {
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
+            "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "node_modules/aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/aws4": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "node_modules/bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dependencies": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "node_modules/bignumber.js": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+            "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+            "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/bluebird": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
+            "integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg=="
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "node_modules/bytes": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+            "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/camel-case": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+            "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+            "dependencies": {
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
+            }
+        },
+        "node_modules/caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "node_modules/cheerio": {
+            "version": "1.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+            "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+            "dependencies": {
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.1",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+            "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+            "dependencies": {
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.5.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.1.2"
+            }
+        },
+        "node_modules/clean-css": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+            "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+            "dependencies": {
+                "source-map": "~0.6.0"
+            },
+            "engines": {
+                "node": ">= 4.0"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/color": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+            "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+            "dependencies": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "node_modules/color-string": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+            "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+            "dependencies": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
+        },
+        "node_modules/colornames": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+            "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
+        },
+        "node_modules/colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/colorspace": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+            "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+            "dependencies": {
+                "color": "3.0.x",
+                "text-hex": "1.0.x"
+            }
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+            "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg=="
+        },
+        "node_modules/component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "node_modules/concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "engines": [
+                "node >= 0.8"
+            ],
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "node_modules/concat-stream/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/concat-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/concat-stream/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/config-chain": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+            "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
+        "node_modules/cookiejar": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+            "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+        },
+        "node_modules/copy-paste": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/copy-paste/-/copy-paste-1.3.0.tgz",
+            "integrity": "sha1-p+bEocKP3t8rCB5yuX3y75X0ce0=",
+            "dependencies": {
+                "iconv-lite": "^0.4.8"
+            },
+            "optionalDependencies": {
+                "sync-exec": "~0.6.x"
+            }
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "node_modules/css-select": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "dependencies": {
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
+                "domutils": "1.5.1",
+                "nth-check": "~1.0.1"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+            "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/data-uri-to-buffer": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+            "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="
+        },
+        "node_modules/debug": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "node_modules/degenerator": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+            "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+            "dependencies": {
+                "ast-types": "0.x.x",
+                "escodegen": "1.x.x",
+                "esprima": "3.x.x"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/detect-node": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+            "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+        },
+        "node_modules/diagnostics": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+            "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+            "dependencies": {
+                "colorspace": "1.1.x",
+                "enabled": "1.0.x",
+                "kuler": "1.0.x"
+            }
+        },
+        "node_modules/dom-serializer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+            "dependencies": {
+                "domelementtype": "^1.3.0",
+                "entities": "^1.1.1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+        },
+        "node_modules/domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "dependencies": {
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dependencies": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dependencies": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "node_modules/editorconfig": {
+            "version": "0.15.3",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+            "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+            "dependencies": {
+                "commander": "^2.19.0",
+                "lru-cache": "^4.1.5",
+                "semver": "^5.6.0",
+                "sigmund": "^1.0.1"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "node_modules/enabled": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+            "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+            "dependencies": {
+                "env-variable": "0.0.x"
+            }
+        },
+        "node_modules/entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        },
+        "node_modules/env-variable": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+            "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
+        },
+        "node_modules/es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+        },
+        "node_modules/es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dependencies": {
+                "es6-promise": "^4.0.3"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-goat": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+            "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/escodegen": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+            "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+            "dependencies": {
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "node_modules/extract-zip": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+            "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+            "dependencies": {
+                "concat-stream": "1.6.2",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.1",
+                "yauzl": "2.4.1"
+            },
+            "bin": {
+                "extract-zip": "cli.js"
+            }
+        },
+        "node_modules/extract-zip/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/extract-zip/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "node_modules/extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "engines": [
+                "node >=0.6.0"
+            ]
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+        },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+        },
+        "node_modules/fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "dependencies": {
+                "pend": "~1.2.0"
+            }
+        },
+        "node_modules/fecha": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+            "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+        },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+        },
+        "node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
+        "node_modules/formidable": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+            "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+        },
+        "node_modules/fs-extra": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+            "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "node_modules/fsevents": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/ftp": {
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+            "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+            "dependencies": {
+                "readable-stream": "1.1.x",
+                "xregexp": "2.0.0"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/ftp/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "node_modules/ftp/node_modules/readable-stream": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "node_modules/ftp/node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-uri": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.3.tgz",
+            "integrity": "sha512-x5j6Ks7FOgLD/GlvjKwgu7wdmMR55iuRHhn8hj/+gA+eSbxQvZ+AEomq+3MgVEZj1vpi738QahGbCCSIDtXtkw==",
+            "dependencies": {
+                "data-uri-to-buffer": "2",
+                "debug": "4",
+                "extend": "~3.0.2",
+                "file-uri-to-path": "1",
+                "ftp": "~0.3.10",
+                "readable-stream": "3"
+            }
+        },
+        "node_modules/get-uri/node_modules/debug": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+        },
+        "node_modules/growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4.x"
+            }
+        },
+        "node_modules/har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dependencies": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/hasha": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+            "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+            "dependencies": {
+                "is-stream": "^1.0.1",
+                "pinkie-promise": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "bin": {
+                "he": "bin/he"
+            }
+        },
+        "node_modules/highlight.js": {
+            "version": "9.15.10",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+            "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/html-minifier": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
+            "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+            "dependencies": {
+                "camel-case": "^3.0.0",
+                "clean-css": "^4.2.1",
+                "commander": "^2.19.0",
+                "he": "^1.2.0",
+                "param-case": "^2.1.1",
+                "relateurl": "^0.2.7",
+                "uglify-js": "^3.5.1"
+            },
+            "bin": {
+                "html-minifier": "cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "dependencies": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+            }
+        },
+        "node_modules/http-errors": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+            "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+            "dependencies": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "dependencies": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "node_modules/http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            },
+            "engines": {
+                "node": ">=0.8",
+                "npm": ">=1.3.7"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+            "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+            "dependencies": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "node_modules/ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "node_modules/isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "node_modules/js-beautify": {
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz",
+            "integrity": "sha512-ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==",
+            "dependencies": {
+                "config-chain": "^1.1.12",
+                "editorconfig": "^0.15.3",
+                "glob": "^7.1.3",
+                "mkdirp": "~0.5.1",
+                "nopt": "~4.0.1"
+            },
+            "bin": {
+                "css-beautify": "js/bin/css-beautify.js",
+                "html-beautify": "js/bin/html-beautify.js",
+                "js-beautify": "js/bin/js-beautify.js"
+            }
+        },
+        "node_modules/jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "node_modules/json-bigint": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.2.3.tgz",
+            "integrity": "sha1-EY1/b/HThlnxn5TPc+ZKdaP5iKg=",
+            "dependencies": {
+                "bignumber.js": "^4.0.0"
+            }
+        },
+        "node_modules/json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "node_modules/jsonfile": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "dependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "dependencies": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "node_modules/juice": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/juice/-/juice-7.0.0.tgz",
+            "integrity": "sha512-AjKQX31KKN+uJs+zaf+GW8mBO/f/0NqSh2moTMyvwBY+4/lXIYTU8D8I2h6BAV3Xnz6GGsbalUyFqbYMe+Vh+Q==",
+            "dependencies": {
+                "cheerio": "^1.0.0-rc.3",
+                "commander": "^5.1.0",
+                "mensch": "^0.3.4",
+                "slick": "^1.12.2",
+                "web-resource-inliner": "^5.0.0"
+            },
+            "bin": {
+                "juice": "bin/juice"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/juice/node_modules/commander": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/kew": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+            "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
+        },
+        "node_modules/klaw": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "dependencies": {
+                "graceful-fs": "^4.1.9"
+            }
+        },
+        "node_modules/kuler": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+            "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+            "dependencies": {
+                "colornames": "^1.1.1"
+            }
+        },
+        "node_modules/levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dependencies": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/linkify-it": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "dev": true,
+            "dependencies": {
+                "uc.micro": "^1.0.1"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "node_modules/logform": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+            "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+            "dependencies": {
+                "colors": "^1.2.1",
+                "fast-safe-stringify": "^2.0.4",
+                "fecha": "^2.3.3",
+                "ms": "^2.1.1",
+                "triple-beam": "^1.3.0"
+            }
+        },
+        "node_modules/lower-case": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+            "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+        },
+        "node_modules/lru-cache": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "dependencies": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+            }
+        },
+        "node_modules/markdown-it": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+            "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "entities": "~1.1.1",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.js"
+            }
+        },
+        "node_modules/markdown-it-anchor": {
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz",
+            "integrity": "sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==",
+            "dev": true
+        },
+        "node_modules/mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+            "dev": true
+        },
+        "node_modules/mensch": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
+            "integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g=="
+        },
+        "node_modules/methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+            "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.24",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+            "dependencies": {
+                "mime-db": "1.40.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "node_modules/mjml": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml/-/mjml-4.8.0.tgz",
+            "integrity": "sha512-nHGC4UH1Nv9lC/yRgF+DcIiGreyXv7AytXnPI7MAXgx3hc25I3Q6w9pjCg11wRBO/iDz/ZTjLbzBejpSkCn45g==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "mjml-accordion": "4.8.0",
+                "mjml-body": "4.8.0",
+                "mjml-button": "4.8.0",
+                "mjml-carousel": "4.8.0",
+                "mjml-cli": "4.8.0",
+                "mjml-column": "4.8.0",
+                "mjml-core": "4.8.0",
+                "mjml-divider": "4.8.0",
+                "mjml-group": "4.8.0",
+                "mjml-head": "4.8.0",
+                "mjml-head-attributes": "4.8.0",
+                "mjml-head-breakpoint": "4.8.0",
+                "mjml-head-font": "4.8.0",
+                "mjml-head-html-attributes": "4.8.0",
+                "mjml-head-preview": "4.8.0",
+                "mjml-head-style": "4.8.0",
+                "mjml-head-title": "4.8.0",
+                "mjml-hero": "4.8.0",
+                "mjml-image": "4.8.0",
+                "mjml-migrate": "4.8.0",
+                "mjml-navbar": "4.8.0",
+                "mjml-raw": "4.8.0",
+                "mjml-section": "4.8.0",
+                "mjml-social": "4.8.0",
+                "mjml-spacer": "4.8.0",
+                "mjml-table": "4.8.0",
+                "mjml-text": "4.8.0",
+                "mjml-validator": "4.8.0",
+                "mjml-wrapper": "4.8.0"
+            },
+            "bin": {
+                "mjml": "bin/mjml"
+            }
+        },
+        "node_modules/mjml-accordion": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-4.8.0.tgz",
+            "integrity": "sha512-ZPj7by6+2bWJwe2NHwTh33JWBmVWlmQ1rdeuSNlJQAuzYZRW8puU8fRRoBVcystG10Ck8EaBy2wtRRhY1zyMwg==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-body": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-4.8.0.tgz",
+            "integrity": "sha512-lVoLnK8NWvChaah5VMObdzNaTkPdJN3FxMDxWL0NWWwx0cZKW4S0C+eE4/DbKGNyS6t05ZuFoAuZwq/dgyuPQw==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-button": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-4.8.0.tgz",
+            "integrity": "sha512-p0idvIL+ad8UnR/YVLlS4m/SkTbMzHcc3Q62X4R2dNXpP4GEuXtjIV202gL2ylJIKjchBeiXwVHIkmnZo/CsLA==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-carousel": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-4.8.0.tgz",
+            "integrity": "sha512-gqjrx20BHL/5cjMqhrUl1Cg8gqHgOES6gYD2zzibnYSLIsrK1obN5k/WsOiiCuLUEO4EYqbEI7eTYlrqLp1FxQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-cli": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-4.8.0.tgz",
+            "integrity": "sha512-HnT/BdSyFQA49COqmi6axkYP7yZDAoR8zDSAUucx99oqr9H8n7s9fAmvbL1egURNPaclwMhG3ibWEybpxULPzw==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "chokidar": "^3.0.0",
+                "glob": "^7.1.1",
+                "html-minifier": "^4.0.0",
+                "js-beautify": "^1.6.14",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0",
+                "mjml-migrate": "4.8.0",
+                "mjml-parser-xml": "4.8.0",
+                "mjml-validator": "4.8.0",
+                "yargs": "^16.1.0"
+            },
+            "bin": {
+                "mjml-cli": "bin/mjml"
+            }
+        },
+        "node_modules/mjml-column": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-4.8.0.tgz",
+            "integrity": "sha512-FdY8fykoX6GMwVt/uS6DfTs0ejvya26AZ2wLJJSjEEo9yKRG40PiG4hYr/n5CCnCQopV8bgY0VX2FzHzw/+0Kg==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-core": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-4.8.0.tgz",
+            "integrity": "sha512-WaaRe7/beu9O7v8MLLI6qVzYDb+TYb2snHqBmgG9cbXGzEgtz3CrTq6z3rZH3PhOOHwagit2URotyeUGqJDQWA==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "cheerio": "1.0.0-rc.3",
+                "detect-node": "2.0.4",
+                "html-minifier": "^4.0.0",
+                "js-beautify": "^1.6.14",
+                "juice": "^7.0.0",
+                "lodash": "^4.17.15",
+                "mjml-migrate": "4.8.0",
+                "mjml-parser-xml": "4.8.0",
+                "mjml-validator": "4.8.0"
+            }
+        },
+        "node_modules/mjml-divider": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-4.8.0.tgz",
+            "integrity": "sha512-i1lxf54+widtQVRiWoa6MaJEM+DBXadqTidLbhGTmxc0+C1SJqErhlu917bnwT/bm9JPgi8RNQxxSpzH+Y4R9Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-group": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-4.8.0.tgz",
+            "integrity": "sha512-jY4FzQnpmb/ULgySlEX/UGxPY7vfw7reMsHguPobIbUaIjREszwjT+ogQySgpV/wBbZg5YNd2UIynMzt3rJV1g==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-head": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-4.8.0.tgz",
+            "integrity": "sha512-UGiAeYCxHEGdXpVuMilOl3Z8BfjiTvDPIuyb08GSKAjbvu1eGmSYe0+P3GiMBP21glGYjzHufcd7qu5NUbgakg==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-head-attributes": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-4.8.0.tgz",
+            "integrity": "sha512-LJrGWTbh0vQxgezqJLXt/Z/1BGlSn9DaKxJyDw5nN4q180DWuAdW3EB0jGKIUJtm64SeoXXpl9hiFLMfMNOxkg==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-head-breakpoint": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-4.8.0.tgz",
+            "integrity": "sha512-TgT7YAZsebblSJB5ScnDObOxiersJfsWvzzvgrC0NFrf+GlftrTAIAuGI8271CYx8G86RdGIfSmoDPXrwgWG6g==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-head-font": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-4.8.0.tgz",
+            "integrity": "sha512-lDvXg6kbaD66MeyoUbKsYiacHaUtqHtjuWdSK8jh20zvY4zxZ9GhILG2reZxzqB3RJBN5Rm2RUyu2tqpKOlqkg==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-head-html-attributes": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-4.8.0.tgz",
+            "integrity": "sha512-m362eRXwpN0nOEk7gDnhoHSv2+e7P0J7Luw1Sg6ox4r9pMrL66U7Tmfi/ZKW9X+V0wpLpxcoVu6wKcX0sJ2k2g==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-head-preview": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-4.8.0.tgz",
+            "integrity": "sha512-b9Wo/VnuAXPRq1jnZYPHo+aQDfWMWURMOGeLyhs73hElhavlEy6EYxMD9LiNnK+6njkYFancwy93wSKv0G7C1w==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-head-style": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-4.8.0.tgz",
+            "integrity": "sha512-lwge9b1b3IvIdwyaST5d5J9M+C3AitR2zOMJm1OrcHTHgoXKXoUYmnGKnZrbCxSl0SgXF7+77Dxo4TrgPrbjxw==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-head-title": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-4.8.0.tgz",
+            "integrity": "sha512-RgwvBojw6ybStPB3Yb/F0LgZu4QjhhFylY66JVdpclU3h7W5rnBgX+RfAN7XQCR4gbgAu8jlyrfWjouAIsZ+fQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-hero": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-4.8.0.tgz",
+            "integrity": "sha512-2RG9A1Z+YN0v4MbqEk9Y1+GZVoPVlGAhyC1qRtpFSo73WOJdxHHLR5GR1/8YWg3FKQ7ZN2R3T4Ui4CehuZ76SA==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-image": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-4.8.0.tgz",
+            "integrity": "sha512-wY8LgR45oqT9I9RqLFvMtoNdQoqpsQ4rd77IPN5vxMZJ35MssHrdPOUnNyymXYSceqPA64sk2pP2NL5u/mr3SQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-migrate": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.8.0.tgz",
+            "integrity": "sha512-okXBzix/xzrFYmkiFJB2aUamD1aU4XWZv1lFHyHW0MAN3qEnTGaukSGgyVO0FbfBJN/Q0Qo71ImklPGc3M0Nyg==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "js-beautify": "^1.6.14",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0",
+                "mjml-parser-xml": "4.8.0",
+                "yargs": "^16.1.0"
+            },
+            "bin": {
+                "migrate": "lib/cli.js"
+            }
+        },
+        "node_modules/mjml-navbar": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-4.8.0.tgz",
+            "integrity": "sha512-xMkW3MG11oM1CyWkFdBtxyOMyrSBg7mWNvhoXXOwM6Fw2NrjFRUWHuNnwXSAXzctUzzf6tPpbFcMQjuTcoLa4g==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-parser-xml": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-4.8.0.tgz",
+            "integrity": "sha512-yGvObDN+HWSLPteUQ2aiCkOAf/we2ac1OtBMLIMyt9nUWZLfiAEsErp3NIg/KlzTGizm7tmcHNdDOrL1z5zv6Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "detect-node": "2.0.4",
+                "htmlparser2": "^4.1.0",
+                "lodash": "^4.17.15"
+            }
+        },
+        "node_modules/mjml-parser-xml/node_modules/dom-serializer": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+            "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "entities": "^2.0.0"
+            }
+        },
+        "node_modules/mjml-parser-xml/node_modules/dom-serializer/node_modules/domhandler": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+            "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+            "dependencies": {
+                "domelementtype": "^2.1.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/mjml-parser-xml/node_modules/domelementtype": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+            "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+        },
+        "node_modules/mjml-parser-xml/node_modules/domhandler": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+            "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+            "dependencies": {
+                "domelementtype": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/mjml-parser-xml/node_modules/domutils": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
+            "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0"
+            }
+        },
+        "node_modules/mjml-parser-xml/node_modules/domutils/node_modules/domhandler": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+            "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+            "dependencies": {
+                "domelementtype": "^2.1.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/mjml-parser-xml/node_modules/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
+        "node_modules/mjml-parser-xml/node_modules/htmlparser2": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+            "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^3.0.0",
+                "domutils": "^2.0.0",
+                "entities": "^2.0.0"
+            }
+        },
+        "node_modules/mjml-raw": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-4.8.0.tgz",
+            "integrity": "sha512-ncasA+YvLqP8S/9Lnx11aPjLnImbtd2LAJpLEf97/cFpBAElWH5F4T2sZjN6P03iAIWzLyVYgsNaMxyx4o8WTw==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-section": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-4.8.0.tgz",
+            "integrity": "sha512-LfaNR3yiRmQQtNbUKHZQq9225myvBsrqEru9q6rBHI3oitRph9NHKpQ8XpguC7elATKz3rryKaBpmob0MnG7bQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-social": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-4.8.0.tgz",
+            "integrity": "sha512-wqDQGzYxqJbWF4KL5DyvO8m7+mXDLbmVuQx0GDGD1JgKhJ6oHJ0rI6niqhF2PaMhym9LNU7f8VeAnnTyzEyYsQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-spacer": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-4.8.0.tgz",
+            "integrity": "sha512-d5eHn44BQXLt1Ef48kmGA+9VO4fc/0oOZV6wJjY10Iknas/M1yOLS0/Z03qz+SAR8O2M2ncvaJUBbklPY7Rn2Q==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-table": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-4.8.0.tgz",
+            "integrity": "sha512-EnBtALi4Mk+nXGJznMQnsYTuX5yyjl5r4KkmixEYhrshHFAT8iAbCIROBk4CnSKGx7nFnfL589W0fJ04Op0y8g==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-text": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-4.8.0.tgz",
+            "integrity": "sha512-w4EHfrnxRPvq/Vv/h3+bR7bR+Mo4LeKVkDA6PA3b0zzR6uNwDWQNg2tf/256NlMnvm6yLNDEyNsh/CA9JgmBxA==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0"
+            }
+        },
+        "node_modules/mjml-validator": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-4.8.0.tgz",
+            "integrity": "sha512-sF0Eg7PacxFmwE9t22xnYQO6hxlSWRPNE3HKgLJ4WD1IQ+DCYv2LlfC1B6U0xmNCyMhiT2bV9IXziIfddrH8Yg==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7"
+            }
+        },
+        "node_modules/mjml-wrapper": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-4.8.0.tgz",
+            "integrity": "sha512-n71jr4W4opG5ADGjMXfInMk11XVX/92X6DxmLT83kNh4aPLkkJAtXfwSCVSYVcg6uBHfDpon9O8OQCVAuJd3iw==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "lodash": "^4.17.15",
+                "mjml-core": "4.8.0",
+                "mjml-section": "4.8.0"
+            }
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dependencies": {
+                "minimist": "0.0.8"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/mocha": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "dev": true,
+            "dependencies": {
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "supports-color": "5.4.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/commander": {
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+            "dev": true
+        },
+        "node_modules/mocha/node_modules/debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/mocha/node_modules/glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/mocha/node_modules/he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true,
+            "bin": {
+                "he": "bin/he"
+            }
+        },
+        "node_modules/mocha/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/mocha/node_modules/supports-color": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/netmask": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+            "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/no-case": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+            "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+            "dependencies": {
+                "lower-case": "^1.1.1"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            }
+        },
+        "node_modules/node-mailjet": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/node-mailjet/-/node-mailjet-3.3.1.tgz",
+            "integrity": "sha512-MMKE5e1vKv3/GMUa6GRZu4rloSNx3Aa/XlOzjr1P7jo9HFSDgzM1V7Tyi/p2/zPzt1nS5BT2vwiaV+YA8l0BcA==",
+            "dependencies": {
+                "bluebird": "^3.5.0",
+                "json-bigint": "^0.2.3",
+                "qs": "^6.5.0",
+                "superagent": "^3.5.2",
+                "superagent-proxy": "^1.0.2"
+            }
+        },
+        "node_modules/nodemailer": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.7.0.tgz",
+            "integrity": "sha512-IludxDypFpYw4xpzKdMAozBSkzKHmNBvGanUREjJItgJ2NYcK/s8+PggVhj7c2yGFQykKsnnmv1+Aqo0ZfjHmw==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/nopt": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+            "dependencies": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm": {
+            "version": "6.11.3",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-6.11.3.tgz",
+            "integrity": "sha512-K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==",
+            "bundleDependencies": [
+                "JSONStream",
+                "abbrev",
+                "agent-base",
+                "agentkeepalive",
+                "ajv",
+                "ansi-align",
+                "ansi-regex",
+                "ansi-styles",
+                "ansicolors",
+                "ansistyles",
+                "aproba",
+                "archy",
+                "are-we-there-yet",
+                "asap",
+                "asn1",
+                "assert-plus",
+                "asynckit",
+                "aws-sign2",
+                "aws4",
+                "balanced-match",
+                "bcrypt-pbkdf",
+                "bin-links",
+                "bluebird",
+                "boxen",
+                "brace-expansion",
+                "buffer-from",
+                "builtins",
+                "byline",
+                "byte-size",
+                "cacache",
+                "call-limit",
+                "camelcase",
+                "capture-stack-trace",
+                "caseless",
+                "chalk",
+                "chownr",
+                "ci-info",
+                "cidr-regex",
+                "cli-boxes",
+                "cli-columns",
+                "cli-table3",
+                "cliui",
+                "clone",
+                "cmd-shim",
+                "co",
+                "code-point-at",
+                "color-convert",
+                "color-name",
+                "colors",
+                "columnify",
+                "combined-stream",
+                "concat-map",
+                "concat-stream",
+                "config-chain",
+                "configstore",
+                "console-control-strings",
+                "copy-concurrently",
+                "core-util-is",
+                "create-error-class",
+                "cross-spawn",
+                "crypto-random-string",
+                "cyclist",
+                "dashdash",
+                "debug",
+                "debuglog",
+                "decamelize",
+                "decode-uri-component",
+                "deep-extend",
+                "defaults",
+                "define-properties",
+                "delayed-stream",
+                "delegates",
+                "detect-indent",
+                "detect-newline",
+                "dezalgo",
+                "dot-prop",
+                "dotenv",
+                "duplexer3",
+                "duplexify",
+                "ecc-jsbn",
+                "editor",
+                "encoding",
+                "end-of-stream",
+                "env-paths",
+                "err-code",
+                "errno",
+                "es-abstract",
+                "es-to-primitive",
+                "es6-promise",
+                "es6-promisify",
+                "escape-string-regexp",
+                "execa",
+                "extend",
+                "extsprintf",
+                "fast-deep-equal",
+                "fast-json-stable-stringify",
+                "figgy-pudding",
+                "find-npm-prefix",
+                "find-up",
+                "flush-write-stream",
+                "forever-agent",
+                "form-data",
+                "from2",
+                "fs-minipass",
+                "fs-vacuum",
+                "fs-write-stream-atomic",
+                "fs.realpath",
+                "function-bind",
+                "gauge",
+                "genfun",
+                "gentle-fs",
+                "get-caller-file",
+                "get-stream",
+                "getpass",
+                "glob",
+                "global-dirs",
+                "got",
+                "graceful-fs",
+                "har-schema",
+                "har-validator",
+                "has",
+                "has-flag",
+                "has-symbols",
+                "has-unicode",
+                "hosted-git-info",
+                "http-cache-semantics",
+                "http-proxy-agent",
+                "http-signature",
+                "https-proxy-agent",
+                "humanize-ms",
+                "iconv-lite",
+                "iferr",
+                "ignore-walk",
+                "import-lazy",
+                "imurmurhash",
+                "infer-owner",
+                "inflight",
+                "inherits",
+                "ini",
+                "init-package-json",
+                "invert-kv",
+                "ip",
+                "ip-regex",
+                "is-callable",
+                "is-ci",
+                "is-cidr",
+                "is-date-object",
+                "is-fullwidth-code-point",
+                "is-installed-globally",
+                "is-npm",
+                "is-obj",
+                "is-path-inside",
+                "is-redirect",
+                "is-regex",
+                "is-retry-allowed",
+                "is-stream",
+                "is-symbol",
+                "is-typedarray",
+                "isarray",
+                "isexe",
+                "isstream",
+                "jsbn",
+                "json-parse-better-errors",
+                "json-schema",
+                "json-schema-traverse",
+                "json-stringify-safe",
+                "jsonparse",
+                "jsprim",
+                "latest-version",
+                "lazy-property",
+                "lcid",
+                "libcipm",
+                "libnpm",
+                "libnpmaccess",
+                "libnpmconfig",
+                "libnpmhook",
+                "libnpmorg",
+                "libnpmpublish",
+                "libnpmsearch",
+                "libnpmteam",
+                "libnpx",
+                "locate-path",
+                "lock-verify",
+                "lockfile",
+                "lodash._baseindexof",
+                "lodash._baseuniq",
+                "lodash._bindcallback",
+                "lodash._cacheindexof",
+                "lodash._createcache",
+                "lodash._createset",
+                "lodash._getnative",
+                "lodash._root",
+                "lodash.clonedeep",
+                "lodash.restparam",
+                "lodash.union",
+                "lodash.uniq",
+                "lodash.without",
+                "lowercase-keys",
+                "lru-cache",
+                "make-dir",
+                "make-fetch-happen",
+                "meant",
+                "mem",
+                "mime-db",
+                "mime-types",
+                "mimic-fn",
+                "minimatch",
+                "minimist",
+                "minipass",
+                "minizlib",
+                "mississippi",
+                "mkdirp",
+                "move-concurrently",
+                "ms",
+                "mute-stream",
+                "node-fetch-npm",
+                "node-gyp",
+                "nopt",
+                "normalize-package-data",
+                "npm-audit-report",
+                "npm-bundled",
+                "npm-cache-filename",
+                "npm-install-checks",
+                "npm-lifecycle",
+                "npm-logical-tree",
+                "npm-package-arg",
+                "npm-packlist",
+                "npm-pick-manifest",
+                "npm-profile",
+                "npm-registry-fetch",
+                "npm-run-path",
+                "npm-user-validate",
+                "npmlog",
+                "number-is-nan",
+                "oauth-sign",
+                "object-assign",
+                "object-keys",
+                "object.getownpropertydescriptors",
+                "once",
+                "opener",
+                "os-homedir",
+                "os-locale",
+                "os-tmpdir",
+                "osenv",
+                "p-finally",
+                "p-limit",
+                "p-locate",
+                "p-try",
+                "package-json",
+                "pacote",
+                "parallel-transform",
+                "path-exists",
+                "path-is-absolute",
+                "path-is-inside",
+                "path-key",
+                "path-parse",
+                "performance-now",
+                "pify",
+                "prepend-http",
+                "process-nextick-args",
+                "promise-inflight",
+                "promise-retry",
+                "promzard",
+                "proto-list",
+                "protoduck",
+                "prr",
+                "pseudomap",
+                "psl",
+                "pump",
+                "pumpify",
+                "punycode",
+                "qrcode-terminal",
+                "qs",
+                "query-string",
+                "qw",
+                "rc",
+                "read",
+                "read-cmd-shim",
+                "read-installed",
+                "read-package-json",
+                "read-package-tree",
+                "readable-stream",
+                "readdir-scoped-modules",
+                "registry-auth-token",
+                "registry-url",
+                "request",
+                "require-directory",
+                "require-main-filename",
+                "resolve-from",
+                "retry",
+                "rimraf",
+                "run-queue",
+                "safe-buffer",
+                "safer-buffer",
+                "semver",
+                "semver-diff",
+                "set-blocking",
+                "sha",
+                "shebang-command",
+                "shebang-regex",
+                "signal-exit",
+                "slash",
+                "slide",
+                "smart-buffer",
+                "socks",
+                "socks-proxy-agent",
+                "sorted-object",
+                "sorted-union-stream",
+                "spdx-correct",
+                "spdx-exceptions",
+                "spdx-expression-parse",
+                "spdx-license-ids",
+                "split-on-first",
+                "sshpk",
+                "ssri",
+                "stream-each",
+                "stream-iterate",
+                "stream-shift",
+                "strict-uri-encode",
+                "string-width",
+                "string_decoder",
+                "stringify-package",
+                "strip-ansi",
+                "strip-eof",
+                "strip-json-comments",
+                "supports-color",
+                "tar",
+                "term-size",
+                "text-table",
+                "through",
+                "through2",
+                "timed-out",
+                "tiny-relative-date",
+                "tough-cookie",
+                "tunnel-agent",
+                "tweetnacl",
+                "typedarray",
+                "uid-number",
+                "umask",
+                "unique-filename",
+                "unique-slug",
+                "unique-string",
+                "unpipe",
+                "unzip-response",
+                "update-notifier",
+                "url-parse-lax",
+                "util-deprecate",
+                "util-extend",
+                "util-promisify",
+                "uuid",
+                "validate-npm-package-license",
+                "validate-npm-package-name",
+                "verror",
+                "wcwidth",
+                "which",
+                "which-module",
+                "wide-align",
+                "widest-line",
+                "worker-farm",
+                "wrap-ansi",
+                "wrappy",
+                "write-file-atomic",
+                "xdg-basedir",
+                "xtend",
+                "y18n",
+                "yallist",
+                "yargs",
+                "yargs-parser"
+            ],
+            "dependencies": {
+                "abbrev": "~1.1.1",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "aproba": "^2.0.0",
+                "archy": "~1.0.0",
+                "bin-links": "^1.1.3",
+                "bluebird": "^3.5.5",
+                "byte-size": "^5.0.1",
+                "cacache": "^12.0.3",
+                "call-limit": "^1.1.1",
+                "chownr": "^1.1.2",
+                "ci-info": "^2.0.0",
+                "cli-columns": "^3.1.2",
+                "cli-table3": "^0.5.1",
+                "cmd-shim": "^3.0.3",
+                "columnify": "~1.5.4",
+                "config-chain": "^1.1.12",
+                "debuglog": "*",
+                "detect-indent": "~5.0.0",
+                "detect-newline": "^2.1.0",
+                "dezalgo": "~1.0.3",
+                "editor": "~1.0.0",
+                "figgy-pudding": "^3.5.1",
+                "find-npm-prefix": "^1.0.2",
+                "fs-vacuum": "~1.2.10",
+                "fs-write-stream-atomic": "~1.0.10",
+                "gentle-fs": "^2.2.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.2",
+                "has-unicode": "~2.0.1",
+                "hosted-git-info": "^2.8.2",
+                "iferr": "^1.0.2",
+                "imurmurhash": "*",
+                "infer-owner": "^1.0.4",
+                "inflight": "~1.0.6",
+                "inherits": "^2.0.4",
+                "ini": "^1.3.5",
+                "init-package-json": "^1.10.3",
+                "is-cidr": "^3.0.0",
+                "json-parse-better-errors": "^1.0.2",
+                "JSONStream": "^1.3.5",
+                "lazy-property": "~1.0.0",
+                "libcipm": "^4.0.3",
+                "libnpm": "^3.0.1",
+                "libnpmaccess": "^3.0.2",
+                "libnpmhook": "^5.0.3",
+                "libnpmorg": "^1.0.1",
+                "libnpmsearch": "^2.0.2",
+                "libnpmteam": "^1.0.2",
+                "libnpx": "^10.2.0",
+                "lock-verify": "^2.1.0",
+                "lockfile": "^1.0.4",
+                "lodash._baseindexof": "*",
+                "lodash._baseuniq": "~4.6.0",
+                "lodash._bindcallback": "*",
+                "lodash._cacheindexof": "*",
+                "lodash._createcache": "*",
+                "lodash._getnative": "*",
+                "lodash.clonedeep": "~4.5.0",
+                "lodash.restparam": "*",
+                "lodash.union": "~4.6.0",
+                "lodash.uniq": "~4.5.0",
+                "lodash.without": "~4.4.0",
+                "lru-cache": "^5.1.1",
+                "meant": "~1.0.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "~0.5.1",
+                "move-concurrently": "^1.0.1",
+                "node-gyp": "^5.0.3",
+                "nopt": "~4.0.1",
+                "normalize-package-data": "^2.5.0",
+                "npm-audit-report": "^1.3.2",
+                "npm-cache-filename": "~1.0.2",
+                "npm-install-checks": "~3.0.0",
+                "npm-lifecycle": "^3.1.3",
+                "npm-package-arg": "^6.1.1",
+                "npm-packlist": "^1.4.4",
+                "npm-pick-manifest": "^3.0.2",
+                "npm-profile": "^4.0.2",
+                "npm-registry-fetch": "^4.0.0",
+                "npm-user-validate": "~1.0.0",
+                "npmlog": "~4.1.2",
+                "once": "~1.4.0",
+                "opener": "^1.5.1",
+                "osenv": "^0.1.5",
+                "pacote": "^9.5.8",
+                "path-is-inside": "~1.0.2",
+                "promise-inflight": "~1.0.1",
+                "qrcode-terminal": "^0.12.0",
+                "query-string": "^6.8.2",
+                "qw": "~1.0.1",
+                "read": "~1.0.7",
+                "read-cmd-shim": "^1.0.4",
+                "read-installed": "~4.0.3",
+                "read-package-json": "^2.1.0",
+                "read-package-tree": "^5.3.1",
+                "readable-stream": "^3.4.0",
+                "readdir-scoped-modules": "^1.1.0",
+                "request": "^2.88.0",
+                "retry": "^0.12.0",
+                "rimraf": "^2.6.3",
+                "safe-buffer": "^5.1.2",
+                "semver": "^5.7.1",
+                "sha": "^3.0.0",
+                "slide": "~1.1.6",
+                "sorted-object": "~2.0.1",
+                "sorted-union-stream": "~2.1.3",
+                "ssri": "^6.0.1",
+                "stringify-package": "^1.0.0",
+                "tar": "^4.4.10",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^1.3.0",
+                "uid-number": "0.0.6",
+                "umask": "~1.1.0",
+                "unique-filename": "^1.1.1",
+                "unpipe": "~1.0.0",
+                "update-notifier": "^2.5.0",
+                "uuid": "^3.3.2",
+                "validate-npm-package-license": "^3.0.4",
+                "validate-npm-package-name": "~3.0.0",
+                "which": "^1.3.1",
+                "worker-farm": "^1.7.0",
+                "write-file-atomic": "^2.4.3"
+            },
+            "bin": {
+                "npm": "bin/npm-cli.js",
+                "npx": "bin/npx-cli.js"
+            }
+        },
+        "node_modules/npm/node_modules/abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "es6-promisify": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/agentkeepalive": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+            "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "humanize-ms": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/ajv": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+            }
+        },
+        "node_modules/npm/node_modules/ansi-align": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+            "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^2.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/ansicolors": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+            "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/ansistyles": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+            "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/aproba": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+            "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/archy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/are-we-there-yet": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+            "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+            }
+        },
+        "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/npm/node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/aws4": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "inBundle": true,
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "dependencies": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "node_modules/npm/node_modules/bin-links": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.3.tgz",
+            "integrity": "sha512-TEwmH4PHU/D009stP+fkkazMJgkBNCv60z01lQ/Mn8E6+ThHoD03svMnBVuCowwXo2nP2qKyKZxKxp58OHRzxw==",
+            "inBundle": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "bluebird": "^3.5.3",
+                "cmd-shim": "^3.0.0",
+                "gentle-fs": "^2.0.1",
+                "graceful-fs": "^4.1.15",
+                "write-file-atomic": "^2.3.0"
+            }
+        },
+        "node_modules/npm/node_modules/bluebird": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/boxen": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+            "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/buffer-from": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/builtins": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+            "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/byline": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+            "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/byte-size": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
+            "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/cacache": {
+            "version": "12.0.3",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+            "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "bluebird": "^3.5.5",
+                "chownr": "^1.1.1",
+                "figgy-pudding": "^3.5.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.1.15",
+                "infer-owner": "^1.0.3",
+                "lru-cache": "^5.1.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.3",
+                "ssri": "^6.0.1",
+                "unique-filename": "^1.1.1",
+                "y18n": "^4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/call-limit": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
+            "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/camelcase": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+            "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/capture-stack-trace": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+            "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "inBundle": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/npm/node_modules/chalk": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/chownr": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+            "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/ci-info": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/cidr-regex": {
+            "version": "2.0.10",
+            "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
+            "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "ip-regex": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/cli-boxes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+            "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/cli-columns": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+            "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^2.0.0",
+                "strip-ansi": "^3.0.1"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/npm/node_modules/cli-table3": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+            "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4.1.0",
+                "string-width": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "optionalDependencies": {
+                "colors": "^1.1.2"
+            }
+        },
+        "node_modules/npm/node_modules/cliui": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/cliui/node_modules/ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/cliui/node_modules/strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/npm/node_modules/cmd-shim": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
+            "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "~0.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/npm/node_modules/code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "^1.1.1"
+            }
+        },
+        "node_modules/npm/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/colors": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+            "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/npm/node_modules/columnify": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+            "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "strip-ansi": "^3.0.0",
+                "wcwidth": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/combined-stream": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/npm/node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "engines": [
+                "node >= 0.8"
+            ],
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/config-chain": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+            "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+            "inBundle": true,
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
+        "node_modules/npm/node_modules/configstore": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+            "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/console-control-strings": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/copy-concurrently": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+            "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/copy-concurrently/node_modules/aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/copy-concurrently/node_modules/iferr": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/create-error-class": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "capture-stack-trace": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            }
+        },
+        "node_modules/npm/node_modules/cross-spawn/node_modules/lru-cache": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+            }
+        },
+        "node_modules/npm/node_modules/cross-spawn/node_modules/yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/crypto-random-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+            "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/cyclist": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+            "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+            "inBundle": true
+        },
+        "node_modules/npm/node_modules/dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/npm/node_modules/debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/debug/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/npm/node_modules/deep-extend": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+            "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/defaults": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+            "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "clone": "^1.0.2"
+            }
+        },
+        "node_modules/npm/node_modules/define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "object-keys": "^1.0.12"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/npm/node_modules/delegates": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/detect-indent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+            "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/detect-newline": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/dezalgo": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+            "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/npm/node_modules/dot-prop": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/dotenv": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+            "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=4.6.0"
+            }
+        },
+        "node_modules/npm/node_modules/duplexer3": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "inBundle": true,
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/npm/node_modules/duplexify": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+            "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/duplexify/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/duplexify/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/editor": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+            "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/encoding": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "~0.4.13"
+            }
+        },
+        "node_modules/npm/node_modules/end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
+        },
+        "node_modules/npm/node_modules/env-paths": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+            "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/err-code": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+            "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/errno": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+            "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "prr": "~1.0.1"
+            },
+            "bin": {
+                "errno": "cli.js"
+            }
+        },
+        "node_modules/npm/node_modules/es-abstract": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+            "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/es-to-primitive": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+            "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "es6-promise": "^4.0.3"
+            }
+        },
+        "node_modules/npm/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/npm/node_modules/execa": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/execa/node_modules/get-stream": {
+            "version": "3.0.0",
+            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/figgy-pudding": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+            "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/find-npm-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+            "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/find-up": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/flush-write-stream": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+            "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
+            }
+        },
+        "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/form-data": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
+        "node_modules/npm/node_modules/from2": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/from2/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/from2/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/fs-minipass": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+            "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^2.2.1"
+            }
+        },
+        "node_modules/npm/node_modules/fs-vacuum": {
+            "version": "1.2.10",
+            "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+            "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "path-is-inside": "^1.0.1",
+                "rimraf": "^2.5.2"
+            }
+        },
+        "node_modules/npm/node_modules/fs-write-stream-atomic": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+            "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
+            }
+        },
+        "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/iferr": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/gauge": {
+            "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/gauge/node_modules/aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/gauge/node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/genfun": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+            "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/gentle-fs": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.2.1.tgz",
+            "integrity": "sha512-e7dRgUM5fsS+7wm2oggZpgcRx6sEvJHXujPH5RzgQ1ziQY4+HuVBYsnUzJwJ+C7mjOJN27DjiFy1TaL+TNltow==",
+            "inBundle": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "aproba": "^1.1.2",
+                "chownr": "^1.1.2",
+                "fs-vacuum": "^1.2.10",
+                "graceful-fs": "^4.1.11",
+                "iferr": "^0.1.5",
+                "infer-owner": "^1.0.4",
+                "mkdirp": "^0.5.1",
+                "path-is-inside": "^1.0.2",
+                "read-cmd-shim": "^1.0.1",
+                "slide": "^1.1.6"
+            }
+        },
+        "node_modules/npm/node_modules/gentle-fs/node_modules/aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/gentle-fs/node_modules/iferr": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/get-caller-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/glob": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/global-dirs": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+            "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/got": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+            "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/got/node_modules/get-stream": {
+            "version": "3.0.0",
+            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/graceful-fs": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/har-validator": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "ajv": "^5.3.0",
+                "har-schema": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/npm/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/has-unicode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/hosted-git-info": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
+            "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^5.1.1"
+            }
+        },
+        "node_modules/npm/node_modules/http-cache-semantics": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+            "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+            "inBundle": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/npm/node_modules/http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            },
+            "engines": {
+                "node": ">=0.8",
+                "npm": ">=1.3.7"
+            }
+        },
+        "node_modules/npm/node_modules/https-proxy-agent": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+            "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/humanize-ms": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+            "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/iconv-lite": {
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/iferr": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+            "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/ignore-walk": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+            "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minimatch": "^3.0.4"
+            }
+        },
+        "node_modules/npm/node_modules/import-lazy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.19"
+            }
+        },
+        "node_modules/npm/node_modules/infer-owner": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/npm/node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/init-package-json": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+            "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^7.1.1",
+                "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+                "promzard": "^0.3.0",
+                "read": "~1.0.1",
+                "read-package-json": "1 || 2",
+                "semver": "2.x || 3.x || 4 || 5",
+                "validate-npm-package-license": "^3.0.1",
+                "validate-npm-package-name": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/ip": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/is-callable": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/is-ci": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+            "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ci-info": "^1.0.0"
+            },
+            "bin": {
+                "is-ci": "bin.js"
+            }
+        },
+        "node_modules/npm/node_modules/is-ci/node_modules/ci-info": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/is-cidr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
+            "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "cidr-regex": "^2.0.10"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/is-date-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/is-installed-globally": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/is-npm": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+            "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/is-path-inside": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-is-inside": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/is-redirect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/is-regex": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+            "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "has": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/is-retry-allowed": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/is-symbol": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+            "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/npm/node_modules/json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "inBundle": true
+        },
+        "node_modules/npm/node_modules/json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+            "engines": [
+                "node >= 0.2.0"
+            ],
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "inBundle": true,
+            "license": "(MIT OR Apache-2.0)",
+            "dependencies": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            },
+            "bin": {
+                "JSONStream": "bin.js"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/latest-version": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+            "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "package-json": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/lazy-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+            "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "invert-kv": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/libcipm": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.3.tgz",
+            "integrity": "sha512-nuIxNtqA+kIkwUiNM/nZ0yPyR7NkSUov6g6mCfFPkYylO1dEovZBL+NZ3axdouS2UOTa8GdnJ7/meSc1/0AIGw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "bin-links": "^1.1.2",
+                "bluebird": "^3.5.1",
+                "figgy-pudding": "^3.5.1",
+                "find-npm-prefix": "^1.0.2",
+                "graceful-fs": "^4.1.11",
+                "ini": "^1.3.5",
+                "lock-verify": "^2.0.2",
+                "mkdirp": "^0.5.1",
+                "npm-lifecycle": "^3.0.0",
+                "npm-logical-tree": "^1.2.1",
+                "npm-package-arg": "^6.1.0",
+                "pacote": "^9.1.0",
+                "read-package-json": "^2.0.13",
+                "rimraf": "^2.6.2",
+                "worker-farm": "^1.6.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpm": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
+            "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "bin-links": "^1.1.2",
+                "bluebird": "^3.5.3",
+                "find-npm-prefix": "^1.0.2",
+                "libnpmaccess": "^3.0.2",
+                "libnpmconfig": "^1.2.1",
+                "libnpmhook": "^5.0.3",
+                "libnpmorg": "^1.0.1",
+                "libnpmpublish": "^1.1.2",
+                "libnpmsearch": "^2.0.2",
+                "libnpmteam": "^1.0.2",
+                "lock-verify": "^2.0.2",
+                "npm-lifecycle": "^3.0.0",
+                "npm-logical-tree": "^1.2.1",
+                "npm-package-arg": "^6.1.0",
+                "npm-profile": "^4.0.2",
+                "npm-registry-fetch": "^4.0.0",
+                "npmlog": "^4.1.2",
+                "pacote": "^9.5.3",
+                "read-package-json": "^2.0.13",
+                "stringify-package": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmaccess": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
+            "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "get-stream": "^4.0.0",
+                "npm-package-arg": "^6.1.0",
+                "npm-registry-fetch": "^4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmconfig": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+            "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "figgy-pudding": "^3.5.1",
+                "find-up": "^3.0.0",
+                "ini": "^1.3.5"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmconfig/node_modules/find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmconfig/node_modules/locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmconfig/node_modules/p-limit": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+            "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmconfig/node_modules/p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmconfig/node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmhook": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
+            "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "figgy-pudding": "^3.4.1",
+                "get-stream": "^4.0.0",
+                "npm-registry-fetch": "^4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmorg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
+            "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "figgy-pudding": "^3.4.1",
+                "get-stream": "^4.0.0",
+                "npm-registry-fetch": "^4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmpublish": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
+            "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "figgy-pudding": "^3.5.1",
+                "get-stream": "^4.0.0",
+                "lodash.clonedeep": "^4.5.0",
+                "normalize-package-data": "^2.4.0",
+                "npm-package-arg": "^6.1.0",
+                "npm-registry-fetch": "^4.0.0",
+                "semver": "^5.5.1",
+                "ssri": "^6.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmsearch": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
+            "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "figgy-pudding": "^3.5.1",
+                "get-stream": "^4.0.0",
+                "npm-registry-fetch": "^4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmteam": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
+            "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "figgy-pudding": "^3.4.1",
+                "get-stream": "^4.0.0",
+                "npm-registry-fetch": "^4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpx": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.0.tgz",
+            "integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "dotenv": "^5.0.1",
+                "npm-package-arg": "^6.0.0",
+                "rimraf": "^2.6.2",
+                "safe-buffer": "^5.1.0",
+                "update-notifier": "^2.3.0",
+                "which": "^1.3.0",
+                "y18n": "^4.0.0",
+                "yargs": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/lock-verify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
+            "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-package-arg": "^6.1.0",
+                "semver": "^5.4.1"
+            }
+        },
+        "node_modules/npm/node_modules/lockfile": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+            "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "node_modules/npm/node_modules/lodash._baseindexof": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+            "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash._baseuniq": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+            "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash._createset": "~4.0.0",
+                "lodash._root": "~3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/lodash._bindcallback": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+            "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash._cacheindexof": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+            "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash._createcache": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+            "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash._getnative": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/lodash._createset": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+            "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash._getnative": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash._root": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash.restparam": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash.union": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+            "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lodash.without": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+            "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/lowercase-keys": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/npm/node_modules/make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "pify": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/make-fetch-happen": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
+            "integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "agentkeepalive": "^3.4.1",
+                "cacache": "^12.0.0",
+                "http-cache-semantics": "^3.8.1",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "lru-cache": "^5.1.1",
+                "mississippi": "^3.0.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^4.0.0",
+                "ssri": "^6.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/meant": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
+            "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/mem": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/mime-db": {
+            "version": "1.35.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+            "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/npm/node_modules/mime-types": {
+            "version": "2.1.19",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+            "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "~1.35.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/npm/node_modules/mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/minipass": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
+            "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/minipass/node_modules/yallist": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+            "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/minizlib": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+            "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^2.2.1"
+            }
+        },
+        "node_modules/npm/node_modules/mississippi": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+            "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^3.0.0",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "0.0.8"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/npm/node_modules/move-concurrently": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+            "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
+            }
+        },
+        "node_modules/npm/node_modules/move-concurrently/node_modules/aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/ms": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/node-fetch-npm": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+            "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "encoding": "^0.1.11",
+                "json-parse-better-errors": "^1.0.0",
+                "safe-buffer": "^5.1.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.3.tgz",
+            "integrity": "sha512-z/JdtkFGUm0QaQUusvloyYuGDub3nUbOo5de1Fz57cM++osBTvQatBUSTlF1k/w8vFHPxxXW6zxGvkxXSpaBkQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "request": "^2.87.0",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^4.4.8",
+                "which": "1"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "1"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp/node_modules/semver": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+            "inBundle": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/npm/node_modules/nopt": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            }
+        },
+        "node_modules/npm/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/normalize-package-data/node_modules/resolve": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "node_modules/npm/node_modules/npm-audit-report": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.2.tgz",
+            "integrity": "sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "cli-table3": "^0.5.0",
+                "console-control-strings": "^1.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-bundled": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+            "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/npm-cache-filename": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+            "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/npm-install-checks": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+            "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^2.3.0 || 3.x || 4 || 5"
+            }
+        },
+        "node_modules/npm/node_modules/npm-lifecycle": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.3.tgz",
+            "integrity": "sha512-M0QmmqbEHBXxDrmc6X3+eKjW9+F7Edg1ENau92WkYw1sox6wojHzEZJIRm1ItljEiaigZlKL8mXni/4ylAy1Dg==",
+            "inBundle": true,
+            "license": "Artistic-2.0",
+            "dependencies": {
+                "byline": "^5.0.0",
+                "graceful-fs": "^4.1.15",
+                "node-gyp": "^5.0.2",
+                "resolve-from": "^4.0.0",
+                "slide": "^1.1.6",
+                "uid-number": "0.0.6",
+                "umask": "^1.1.0",
+                "which": "^1.3.1"
+            }
+        },
+        "node_modules/npm/node_modules/npm-logical-tree": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+            "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/npm-package-arg": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+            "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^2.7.1",
+                "osenv": "^0.1.5",
+                "semver": "^5.6.0",
+                "validate-npm-package-name": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-packlist": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+            "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/npm-pick-manifest": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
+            "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "figgy-pudding": "^3.5.1",
+                "npm-package-arg": "^6.0.0",
+                "semver": "^5.4.1"
+            }
+        },
+        "node_modules/npm/node_modules/npm-profile": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.2.tgz",
+            "integrity": "sha512-VRsC04pvRH+9cF+PoVh2nTmJjiG21yu59IHpsBpkxk+jaGAV8lxx96G4SDc0jOHAkfWLXbc6kIph3dGAuRnotQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.1.2 || 2",
+                "figgy-pudding": "^3.4.1",
+                "npm-registry-fetch": "^4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-registry-fetch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.0.tgz",
+            "integrity": "sha512-Jllq35Jag8dtv0M17ue74XtdQTyqKzuAYGiX9mAjOhkmNjib3bBUgK6mUY61+AHnXeSRobQkpY3/xIOS/omptw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "bluebird": "^3.5.1",
+                "figgy-pudding": "^3.4.1",
+                "JSONStream": "^1.3.4",
+                "lru-cache": "^5.1.1",
+                "make-fetch-happen": "^5.0.0",
+                "npm-package-arg": "^6.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/npm-user-validate": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+            "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
+            "inBundle": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/npm/node_modules/npmlog": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/object-keys": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/npm/node_modules/object.getownpropertydescriptors": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+            "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/npm/node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/npm/node_modules/opener": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+            "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+            "inBundle": true,
+            "license": "(WTFPL OR MIT)",
+            "bin": {
+                "opener": "bin/opener-bin.js"
+            }
+        },
+        "node_modules/npm/node_modules/os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/os-locale": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/p-limit": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-try": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/package-json": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+            "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/pacote": {
+            "version": "9.5.8",
+            "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.8.tgz",
+            "integrity": "sha512-0Tl8Oi/K0Lo4MZmH0/6IsT3gpGf9eEAznLXEQPKgPq7FscnbUOyopnVpwXlnQdIbCUaojWy1Wd7VMyqfVsRrIw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "bluebird": "^3.5.3",
+                "cacache": "^12.0.2",
+                "chownr": "^1.1.2",
+                "figgy-pudding": "^3.5.1",
+                "get-stream": "^4.1.0",
+                "glob": "^7.1.3",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^5.1.1",
+                "make-fetch-happen": "^5.0.0",
+                "minimatch": "^3.0.4",
+                "minipass": "^2.3.5",
+                "mississippi": "^3.0.0",
+                "mkdirp": "^0.5.1",
+                "normalize-package-data": "^2.4.0",
+                "npm-package-arg": "^6.1.0",
+                "npm-packlist": "^1.1.12",
+                "npm-pick-manifest": "^3.0.0",
+                "npm-registry-fetch": "^4.0.0",
+                "osenv": "^0.1.5",
+                "promise-inflight": "^1.0.1",
+                "promise-retry": "^1.1.1",
+                "protoduck": "^5.0.1",
+                "rimraf": "^2.6.2",
+                "safe-buffer": "^5.1.2",
+                "semver": "^5.6.0",
+                "ssri": "^6.0.1",
+                "tar": "^4.4.10",
+                "unique-filename": "^1.1.1",
+                "which": "^1.3.1"
+            }
+        },
+        "node_modules/npm/node_modules/pacote/node_modules/minipass": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/parallel-transform": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+            "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
+            }
+        },
+        "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "inBundle": true,
+            "license": "(WTFPL OR MIT)"
+        },
+        "node_modules/npm/node_modules/path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/promise-inflight": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+            "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/promise-retry": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+            "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "err-code": "^1.0.0",
+                "retry": "^0.10.0"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/npm/node_modules/promise-retry/node_modules/retry": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+            "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/promzard": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+            "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "read": "1"
+            }
+        },
+        "node_modules/npm/node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/protoduck": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+            "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "genfun": "^5.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/psl": {
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "node_modules/npm/node_modules/pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/pumpify/node_modules/pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "node_modules/npm/node_modules/punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/qrcode-terminal": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+            "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+            "inBundle": true,
+            "bin": {
+                "qrcode-terminal": "bin/qrcode-terminal.js"
+            }
+        },
+        "node_modules/npm/node_modules/qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "inBundle": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/npm/node_modules/query-string": {
+            "version": "6.8.2",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+            "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "decode-uri-component": "^0.2.0",
+                "split-on-first": "^1.0.0",
+                "strict-uri-encode": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/qw": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+            "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/rc": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+            "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+            "inBundle": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/npm/node_modules/rc/node_modules/minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "mute-stream": "~0.0.4"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/npm/node_modules/read-cmd-shim": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.4.tgz",
+            "integrity": "sha512-Pqpl3qJ/QdOIjRYA0q5DND/gLvGOfpIz/fYVDGYpOXfW/lFrIttmLsBnd6IkyK10+JHU9zhsaudfvrQTBB9YFQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "graceful-fs": "^4.1.2"
+            }
+        },
+        "node_modules/npm/node_modules/read-installed": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+            "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "debuglog": "^1.0.1",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "slide": "~1.1.3",
+                "util-extend": "^1.0.1"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.2"
+            }
+        },
+        "node_modules/npm/node_modules/read-package-json": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.0.tgz",
+            "integrity": "sha512-KLhu8M1ZZNkMcrq1+0UJbR8Dii8KZUqB0Sha4mOx/bknfKI/fyrQVrG/YIt2UOtG667sD8+ee4EXMM91W9dC+A==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^7.1.1",
+                "json-parse-better-errors": "^1.0.1",
+                "normalize-package-data": "^2.0.0",
+                "slash": "^1.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.2"
+            }
+        },
+        "node_modules/npm/node_modules/read-package-tree": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+            "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "util-promisify": "^2.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/readable-stream": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+            "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/npm/node_modules/readdir-scoped-modules": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+            "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
+            }
+        },
+        "node_modules/npm/node_modules/registry-auth-token": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+            "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/registry-url": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+            "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/npm/node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/npm/node_modules/rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^7.1.3"
+            },
+            "bin": {
+                "rimraf": "bin.js"
+            }
+        },
+        "node_modules/npm/node_modules/run-queue": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+            "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.1.1"
+            }
+        },
+        "node_modules/npm/node_modules/run-queue/node_modules/aproba": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/npm/node_modules/semver-diff": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+            "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^5.0.3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/sha": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
+            "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
+            "inBundle": true,
+            "license": "(BSD-2-Clause OR MIT)",
+            "dependencies": {
+                "graceful-fs": "^4.1.2"
+            }
+        },
+        "node_modules/npm/node_modules/shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/slash": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/slide": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+            "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/smart-buffer": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+            "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/socks": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+            "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ip": "^1.1.5",
+                "smart-buffer": "4.0.2"
+            },
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/socks-proxy-agent": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+            "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "~4.2.1",
+                "socks": "~2.3.2"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/npm/node_modules/socks-proxy-agent/node_modules/agent-base": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+            "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "es6-promisify": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/sorted-object": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+            "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
+            "inBundle": true,
+            "license": "(WTFPL OR MIT)"
+        },
+        "node_modules/npm/node_modules/sorted-union-stream": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+            "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "from2": "^1.3.0",
+                "stream-iterate": "^1.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+            "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
+            }
+        },
+        "node_modules/npm/node_modules/sorted-union-stream/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/sorted-union-stream/node_modules/readable-stream": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            }
+        },
+        "node_modules/npm/node_modules/sorted-union-stream/node_modules/string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/spdx-correct": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/spdx-exceptions": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+            "inBundle": true,
+            "license": "CC-BY-3.0"
+        },
+        "node_modules/npm/node_modules/spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/spdx-license-ids": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+            "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+            "inBundle": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/npm/node_modules/split-on-first": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+            "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/sshpk": {
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "getpass": "^0.1.1",
+                "safer-buffer": "^2.0.2"
+            },
+            "bin": {
+                "sshpk-conv": "bin/sshpk-conv",
+                "sshpk-sign": "bin/sshpk-sign",
+                "sshpk-verify": "bin/sshpk-verify"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "optionalDependencies": {
+                "bcrypt-pbkdf": "^1.0.0",
+                "ecc-jsbn": "~0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "node_modules/npm/node_modules/ssri": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+            "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "figgy-pudding": "^3.5.1"
+            }
+        },
+        "node_modules/npm/node_modules/stream-each": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+            "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/stream-iterate": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+            "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "readable-stream": "^2.1.5",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/strict-uri-encode": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+            "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/string_decoder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+            "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/string-width/node_modules/is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/stringify-package": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
+            "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/supports-color": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/tar": {
+            "version": "4.4.10",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+            "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.5",
+                "minizlib": "^1.2.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.3"
+            },
+            "engines": {
+                "node": ">=4.5"
+            }
+        },
+        "node_modules/npm/node_modules/tar/node_modules/minipass": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/tar/node_modules/yallist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+            "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/term-size": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+            "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^0.7.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/through2/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/npm/node_modules/through2/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/tiny-relative-date": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
+            "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "inBundle": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/npm/node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "inBundle": true,
+            "license": "Unlicense",
+            "optional": true
+        },
+        "node_modules/npm/node_modules/typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/uid-number": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+            "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/npm/node_modules/umask": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+            "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/unique-filename": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+            "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "unique-slug": "^2.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/unique-slug": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+            "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            }
+        },
+        "node_modules/npm/node_modules/unique-string": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+            "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "crypto-random-string": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/npm/node_modules/unzip-response": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+            "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/update-notifier": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+            "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/url-parse-lax": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "prepend-http": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/util-extend": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+            "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/util-promisify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+            "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
+        "node_modules/npm/node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/npm/node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/validate-npm-package-name": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+            "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "builtins": "^1.0.3"
+            }
+        },
+        "node_modules/npm/node_modules/verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "node_modules/npm/node_modules/wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "defaults": "^1.0.3"
+            }
+        },
+        "node_modules/npm/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
+        "node_modules/npm/node_modules/which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/wide-align": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+            "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^1.0.2"
+            }
+        },
+        "node_modules/npm/node_modules/wide-align/node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/widest-line": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+            "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/worker-farm": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+            "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "errno": "~0.1.7"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm/node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/write-file-atomic": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+            "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "node_modules/npm/node_modules/xdg-basedir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+            "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
+        "node_modules/npm/node_modules/y18n": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/yallist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+            "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/yargs": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+            "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+            }
+        },
+        "node_modules/npm/node_modules/yargs-parser": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+            "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "camelcase": "^4.1.0"
+            }
+        },
+        "node_modules/npm/node_modules/yargs/node_modules/y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "dependencies": {
+                "boolbase": "~1.0.0"
+            }
+        },
+        "node_modules/oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/one-time": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+            "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
+        },
+        "node_modules/optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dependencies": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dependencies": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
+        },
+        "node_modules/pac-proxy-agent": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
+            "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
+            "dependencies": {
+                "agent-base": "^4.2.0",
+                "debug": "^3.1.0",
+                "get-uri": "^2.0.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "pac-resolver": "^3.0.0",
+                "raw-body": "^2.2.0",
+                "socks-proxy-agent": "^3.0.0"
+            }
+        },
+        "node_modules/pac-resolver": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
+            "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+            "dependencies": {
+                "co": "^4.6.0",
+                "degenerator": "^1.0.4",
+                "ip": "^1.1.5",
+                "netmask": "^1.0.6",
+                "thunkify": "^2.1.2"
+            }
+        },
+        "node_modules/param-case": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+            "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+            "dependencies": {
+                "no-case": "^2.2.0"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+            "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+        },
+        "node_modules/performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "node_modules/phantom": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/phantom/-/phantom-6.3.0.tgz",
+            "integrity": "sha512-Ptlwjp5eJiBmr3KQzFr9V/ehhcC+PGyJB38q7mnxJiwrssOEtmIWDEzQ7gIsdOXlHoW0n0+KjdAdP9U89Cm9Pw==",
+            "dependencies": {
+                "phantomjs-prebuilt": "^2.1.16",
+                "split": "^1.0.1",
+                "winston": "^3.2.1"
+            },
+            "bin": {
+                "phantom": "bin/phantom.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/phantomjs-prebuilt": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+            "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+            "hasInstallScript": true,
+            "dependencies": {
+                "es6-promise": "^4.0.3",
+                "extract-zip": "^1.6.5",
+                "fs-extra": "^1.0.0",
+                "hasha": "^2.2.0",
+                "kew": "^0.7.0",
+                "progress": "^1.1.8",
+                "request": "^2.81.0",
+                "request-progress": "^2.0.1",
+                "which": "^1.2.10"
+            },
+            "bin": {
+                "phantomjs": "bin/phantomjs"
+            }
+        },
+        "node_modules/picomatch": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dependencies": {
+                "pinkie": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "node_modules/progress": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+        },
+        "node_modules/proxy-agent": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
+            "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
+            "dependencies": {
+                "agent-base": "^4.2.0",
+                "debug": "^3.1.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "lru-cache": "^4.1.2",
+                "pac-proxy-agent": "^2.0.1",
+                "proxy-from-env": "^1.0.0",
+                "socks-proxy-agent": "^3.0.0"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+        },
+        "node_modules/pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "node_modules/psl": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+            "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+        },
+        "node_modules/punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/querystringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+            "dev": true
+        },
+        "node_modules/raw-body": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+            "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+            "dependencies": {
+                "bytes": "3.1.0",
+                "http-errors": "1.7.3",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+            "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.13.7",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+            "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        },
+        "node_modules/relateurl": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+            "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "dependencies": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/request-progress": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+            "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+            "dependencies": {
+                "throttleit": "^1.0.0"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+            "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "node_modules/sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+        },
+        "node_modules/simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "dependencies": {
+                "is-arrayish": "^0.3.1"
+            }
+        },
+        "node_modules/slick": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+            "integrity": "sha1-vQSN23TefRymkV+qSldXCzVQwtc=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/smart-buffer": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+            "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
+            "engines": {
+                "node": ">= 0.10.15",
+                "npm": ">= 1.3.5"
+            }
+        },
+        "node_modules/socks": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+            "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+            "dependencies": {
+                "ip": "^1.1.4",
+                "smart-buffer": "^1.0.13"
+            },
+            "engines": {
+                "node": ">= 0.10.0",
+                "npm": ">= 1.3.5"
+            }
+        },
+        "node_modules/socks-proxy-agent": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+            "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
+            "dependencies": {
+                "agent-base": "^4.1.0",
+                "socks": "^1.1.10"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+            "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+            "dev": true,
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "node_modules/sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dependencies": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+            "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "dependencies": {
+                "ansi-regex": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/superagent": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+            "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+            "dependencies": {
+                "component-emitter": "^1.2.0",
+                "cookiejar": "^2.1.0",
+                "debug": "^3.1.0",
+                "extend": "^3.0.0",
+                "form-data": "^2.3.1",
+                "formidable": "^1.2.0",
+                "methods": "^1.1.1",
+                "mime": "^1.4.1",
+                "qs": "^6.5.1",
+                "readable-stream": "^2.3.5"
+            },
+            "engines": {
+                "node": ">= 4.0"
+            }
+        },
+        "node_modules/superagent-proxy": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.3.tgz",
+            "integrity": "sha512-79Ujg1lRL2ICfuHUdX+H2MjIw73kB7bXsIkxLwHURz3j0XUmEEEoJ+u/wq+mKwna21Uejsm2cGR3OESA00TIjA==",
+            "dependencies": {
+                "debug": "^3.1.0",
+                "proxy-agent": "2"
+            }
+        },
+        "node_modules/superagent/node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/superagent/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/superagent/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/superagent/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/sync-exec": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.6.2.tgz",
+            "integrity": "sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=",
+            "optional": true
+        },
+        "node_modules/text-hex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+        },
+        "node_modules/throttleit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+            "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "node_modules/thunkify": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+            "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "dependencies": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/tough-cookie/node_modules/punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "node_modules/triple-beam": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        },
+        "node_modules/type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dependencies": {
+                "prelude-ls": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
+        "node_modules/typescript": {
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+            "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+            "dev": true
+        },
+        "node_modules/uglify-js": {
+            "version": "3.12.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.3.tgz",
+            "integrity": "sha512-feZzR+kIcSVuLi3s/0x0b2Tx4Iokwqt+8PJM7yRHKuldg4MLdam4TCFeICv+lgDtuYiCtdmrtIP+uN9LWvDasw==",
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/upper-case": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+            "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+        },
+        "node_modules/uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/url-parse": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+            "dev": true,
+            "dependencies": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "node_modules/uuid": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+            "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/valid-data-url": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
+            "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "node_modules/vscode": {
+            "version": "1.1.36",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.36.tgz",
+            "integrity": "sha512-cGFh9jmGLcTapCpPCKvn8aG/j9zVQ+0x5hzYJq5h5YyUXVGa1iamOaB2M2PZXoumQPES4qeAP1FwkI0b6tL4bQ==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.2",
+                "mocha": "^5.2.0",
+                "request": "^2.88.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.4",
+                "vscode-test": "^0.4.1"
+            },
+            "bin": {
+                "vscode-install": "bin/install"
+            },
+            "engines": {
+                "node": ">=8.9.3"
+            }
+        },
+        "node_modules/vscode-test": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+            "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+            "dev": true,
+            "dependencies": {
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.9.3"
+            }
+        },
+        "node_modules/web-resource-inliner": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-5.0.0.tgz",
+            "integrity": "sha512-AIihwH+ZmdHfkJm7BjSXiEClVt4zUFqX4YlFAzjL13wLtDuUneSaFvDBTbdYRecs35SiU7iNKbMnN+++wVfb6A==",
+            "dependencies": {
+                "ansi-colors": "^4.1.1",
+                "escape-goat": "^3.0.0",
+                "htmlparser2": "^4.0.0",
+                "mime": "^2.4.6",
+                "node-fetch": "^2.6.0",
+                "valid-data-url": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/web-resource-inliner/node_modules/dom-serializer": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+            "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "entities": "^2.0.0"
+            }
+        },
+        "node_modules/web-resource-inliner/node_modules/dom-serializer/node_modules/domhandler": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+            "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+            "dependencies": {
+                "domelementtype": "^2.1.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/web-resource-inliner/node_modules/domelementtype": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+            "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
+        },
+        "node_modules/web-resource-inliner/node_modules/domhandler": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+            "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+            "dependencies": {
+                "domelementtype": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/web-resource-inliner/node_modules/domutils": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
+            "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0"
+            }
+        },
+        "node_modules/web-resource-inliner/node_modules/domutils/node_modules/domhandler": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+            "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
+            "dependencies": {
+                "domelementtype": "^2.1.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/web-resource-inliner/node_modules/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
+        "node_modules/web-resource-inliner/node_modules/htmlparser2": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+            "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^3.0.0",
+                "domutils": "^2.0.0",
+                "entities": "^2.0.0"
+            }
+        },
+        "node_modules/web-resource-inliner/node_modules/mime": {
+            "version": "2.4.7",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+            "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
+        "node_modules/winston": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+            "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+            "dependencies": {
+                "async": "^2.6.1",
+                "diagnostics": "^1.1.1",
+                "is-stream": "^1.1.0",
+                "logform": "^2.1.1",
+                "one-time": "0.0.4",
+                "readable-stream": "^3.1.1",
+                "stack-trace": "0.0.x",
+                "triple-beam": "^1.3.0",
+                "winston-transport": "^4.3.0"
+            },
+            "engines": {
+                "node": ">= 6.4.0"
+            }
+        },
+        "node_modules/winston-transport": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+            "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+            "dependencies": {
+                "readable-stream": "^2.3.6",
+                "triple-beam": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 6.4.0"
+            }
+        },
+        "node_modules/winston-transport/node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/winston-transport/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/winston-transport/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/winston/node_modules/async": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dependencies": {
+                "lodash": "^4.17.14"
+            }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "node_modules/xregexp": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+            "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+        },
+        "node_modules/y18n": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+            "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "20.2.4",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yauzl": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+            "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+            "dependencies": {
+                "fd-slicer": "~1.0.1"
+            }
+        }
+    },
     "dependencies": {
         "@babel/runtime": {
             "version": "7.12.5",
@@ -1877,7 +10370,6 @@
             "resolved": "https://registry.npmjs.org/npm/-/npm-6.11.3.tgz",
             "integrity": "sha512-K2h+MPzZiY39Xf6eHEdECe/LKoJXam4UCflz5kIxoskN3LQFeYs5fqBGT5i4TtM/aBk+86Mcf+jgXs/WuWAutQ==",
             "requires": {
-                "JSONStream": "^1.3.5",
                 "abbrev": "~1.1.1",
                 "ansicolors": "~0.3.2",
                 "ansistyles": "~0.1.3",
@@ -1918,6 +10410,7 @@
                 "init-package-json": "^1.10.3",
                 "is-cidr": "^3.0.0",
                 "json-parse-better-errors": "^1.0.2",
+                "JSONStream": "^1.3.5",
                 "lazy-property": "~1.0.0",
                 "libcipm": "^4.0.3",
                 "libnpm": "^3.0.1",
@@ -2002,20 +10495,16 @@
                 "write-file-atomic": "^2.4.3"
             },
             "dependencies": {
-                "JSONStream": {
-                    "version": "1.3.5",
-                    "bundled": true,
-                    "requires": {
-                        "jsonparse": "^1.2.0",
-                        "through": ">=2.2.7 <3"
-                    }
-                },
                 "abbrev": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+                    "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                     "bundled": true
                 },
                 "agent-base": {
                     "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+                    "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
                     "bundled": true,
                     "requires": {
                         "es6-promisify": "^5.0.0"
@@ -2023,6 +10512,8 @@
                 },
                 "agentkeepalive": {
                     "version": "3.5.2",
+                    "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+                    "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
                     "bundled": true,
                     "requires": {
                         "humanize-ms": "^1.2.1"
@@ -2030,6 +10521,8 @@
                 },
                 "ajv": {
                     "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                     "bundled": true,
                     "requires": {
                         "co": "^4.6.0",
@@ -2040,6 +10533,8 @@
                 },
                 "ansi-align": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+                    "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                     "bundled": true,
                     "requires": {
                         "string-width": "^2.0.0"
@@ -2047,10 +10542,14 @@
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "bundled": true
                 },
                 "ansi-styles": {
                     "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "bundled": true,
                     "requires": {
                         "color-convert": "^1.9.0"
@@ -2058,22 +10557,32 @@
                 },
                 "ansicolors": {
                     "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+                    "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
                     "bundled": true
                 },
                 "ansistyles": {
                     "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+                    "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
                     "bundled": true
                 },
                 "aproba": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+                    "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
                     "bundled": true
                 },
                 "archy": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+                    "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
                     "bundled": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+                    "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
                     "bundled": true,
                     "requires": {
                         "delegates": "^1.0.0",
@@ -2082,6 +10591,8 @@
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -2095,6 +10606,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -2104,10 +10617,14 @@
                 },
                 "asap": {
                     "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+                    "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
                     "bundled": true
                 },
                 "asn1": {
                     "version": "0.2.4",
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+                    "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
                     "bundled": true,
                     "requires": {
                         "safer-buffer": "~2.1.0"
@@ -2115,26 +10632,38 @@
                 },
                 "assert-plus": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                     "bundled": true
                 },
                 "asynckit": {
                     "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                     "bundled": true
                 },
                 "aws-sign2": {
                     "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
                     "bundled": true
                 },
                 "aws4": {
                     "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+                    "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
                     "bundled": true
                 },
                 "balanced-match": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                     "bundled": true
                 },
                 "bcrypt-pbkdf": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+                    "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
                     "bundled": true,
                     "optional": true,
                     "requires": {
@@ -2143,6 +10672,8 @@
                 },
                 "bin-links": {
                     "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.3.tgz",
+                    "integrity": "sha512-TEwmH4PHU/D009stP+fkkazMJgkBNCv60z01lQ/Mn8E6+ThHoD03svMnBVuCowwXo2nP2qKyKZxKxp58OHRzxw==",
                     "bundled": true,
                     "requires": {
                         "bluebird": "^3.5.3",
@@ -2154,10 +10685,14 @@
                 },
                 "bluebird": {
                     "version": "3.5.5",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+                    "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
                     "bundled": true
                 },
                 "boxen": {
                     "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+                    "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
                     "bundled": true,
                     "requires": {
                         "ansi-align": "^2.0.0",
@@ -2171,6 +10706,8 @@
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "bundled": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
@@ -2179,22 +10716,32 @@
                 },
                 "buffer-from": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+                    "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
                     "bundled": true
                 },
                 "builtins": {
                     "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+                    "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
                     "bundled": true
                 },
                 "byline": {
                     "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+                    "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
                     "bundled": true
                 },
                 "byte-size": {
                     "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
+                    "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
                     "bundled": true
                 },
                 "cacache": {
                     "version": "12.0.3",
+                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+                    "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
                     "bundled": true,
                     "requires": {
                         "bluebird": "^3.5.5",
@@ -2216,22 +10763,32 @@
                 },
                 "call-limit": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
+                    "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
                     "bundled": true
                 },
                 "camelcase": {
                     "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                     "bundled": true
                 },
                 "capture-stack-trace": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                    "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
                     "bundled": true
                 },
                 "caseless": {
                     "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
                     "bundled": true
                 },
                 "chalk": {
                     "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "bundled": true,
                     "requires": {
                         "ansi-styles": "^3.2.1",
@@ -2241,14 +10798,20 @@
                 },
                 "chownr": {
                     "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+                    "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
                     "bundled": true
                 },
                 "ci-info": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+                    "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
                     "bundled": true
                 },
                 "cidr-regex": {
                     "version": "2.0.10",
+                    "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
+                    "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
                     "bundled": true,
                     "requires": {
                         "ip-regex": "^2.1.0"
@@ -2256,10 +10819,14 @@
                 },
                 "cli-boxes": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                    "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
                     "bundled": true
                 },
                 "cli-columns": {
                     "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+                    "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
                     "bundled": true,
                     "requires": {
                         "string-width": "^2.0.0",
@@ -2268,6 +10835,8 @@
                 },
                 "cli-table3": {
                     "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+                    "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
                     "bundled": true,
                     "requires": {
                         "colors": "^1.1.2",
@@ -2277,6 +10846,8 @@
                 },
                 "cliui": {
                     "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "bundled": true,
                     "requires": {
                         "string-width": "^2.1.1",
@@ -2286,10 +10857,14 @@
                     "dependencies": {
                         "ansi-regex": {
                             "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                             "bundled": true
                         },
                         "strip-ansi": {
                             "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "bundled": true,
                             "requires": {
                                 "ansi-regex": "^3.0.0"
@@ -2299,10 +10874,14 @@
                 },
                 "clone": {
                     "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
                     "bundled": true
                 },
                 "cmd-shim": {
                     "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
+                    "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
@@ -2311,14 +10890,20 @@
                 },
                 "co": {
                     "version": "4.6.0",
+                    "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                    "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                     "bundled": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                     "bundled": true
                 },
                 "color-convert": {
                     "version": "1.9.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+                    "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
                     "bundled": true,
                     "requires": {
                         "color-name": "^1.1.1"
@@ -2326,15 +10911,21 @@
                 },
                 "color-name": {
                     "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
                     "bundled": true
                 },
                 "colors": {
                     "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+                    "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
                     "bundled": true,
                     "optional": true
                 },
                 "columnify": {
                     "version": "1.5.4",
+                    "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+                    "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
                     "bundled": true,
                     "requires": {
                         "strip-ansi": "^3.0.0",
@@ -2343,6 +10934,8 @@
                 },
                 "combined-stream": {
                     "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                    "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                     "bundled": true,
                     "requires": {
                         "delayed-stream": "~1.0.0"
@@ -2350,10 +10943,14 @@
                 },
                 "concat-map": {
                     "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                     "bundled": true
                 },
                 "concat-stream": {
                     "version": "1.6.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
                     "bundled": true,
                     "requires": {
                         "buffer-from": "^1.0.0",
@@ -2364,6 +10961,8 @@
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -2377,6 +10976,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -2386,6 +10987,8 @@
                 },
                 "config-chain": {
                     "version": "1.1.12",
+                    "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+                    "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
                     "bundled": true,
                     "requires": {
                         "ini": "^1.3.4",
@@ -2394,6 +10997,8 @@
                 },
                 "configstore": {
                     "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+                    "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
                     "bundled": true,
                     "requires": {
                         "dot-prop": "^4.1.0",
@@ -2406,10 +11011,14 @@
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+                    "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
                     "bundled": true
                 },
                 "copy-concurrently": {
                     "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+                    "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
                     "bundled": true,
                     "requires": {
                         "aproba": "^1.1.1",
@@ -2422,20 +11031,28 @@
                     "dependencies": {
                         "aproba": {
                             "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "bundled": true
                         },
                         "iferr": {
                             "version": "0.1.5",
+                            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+                            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
                             "bundled": true
                         }
                     }
                 },
                 "core-util-is": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                     "bundled": true
                 },
                 "create-error-class": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                    "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                     "bundled": true,
                     "requires": {
                         "capture-stack-trace": "^1.0.0"
@@ -2443,6 +11060,8 @@
                 },
                 "cross-spawn": {
                     "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "bundled": true,
                     "requires": {
                         "lru-cache": "^4.0.1",
@@ -2452,6 +11071,8 @@
                     "dependencies": {
                         "lru-cache": {
                             "version": "4.1.5",
+                            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+                            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
                             "bundled": true,
                             "requires": {
                                 "pseudomap": "^1.0.2",
@@ -2460,20 +11081,28 @@
                         },
                         "yallist": {
                             "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                             "bundled": true
                         }
                     }
                 },
                 "crypto-random-string": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+                    "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
                     "bundled": true
                 },
                 "cyclist": {
                     "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                    "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
                     "bundled": true
                 },
                 "dashdash": {
                     "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                    "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                     "bundled": true,
                     "requires": {
                         "assert-plus": "^1.0.0"
@@ -2481,6 +11110,8 @@
                 },
                 "debug": {
                     "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                     "bundled": true,
                     "requires": {
                         "ms": "2.0.0"
@@ -2488,28 +11119,40 @@
                     "dependencies": {
                         "ms": {
                             "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                             "bundled": true
                         }
                     }
                 },
                 "debuglog": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+                    "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
                     "bundled": true
                 },
                 "decamelize": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                     "bundled": true
                 },
                 "decode-uri-component": {
                     "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+                    "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
                     "bundled": true
                 },
                 "deep-extend": {
                     "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+                    "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
                     "bundled": true
                 },
                 "defaults": {
                     "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                    "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                     "bundled": true,
                     "requires": {
                         "clone": "^1.0.2"
@@ -2517,6 +11160,8 @@
                 },
                 "define-properties": {
                     "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+                    "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
                     "bundled": true,
                     "requires": {
                         "object-keys": "^1.0.12"
@@ -2524,22 +11169,32 @@
                 },
                 "delayed-stream": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                     "bundled": true
                 },
                 "delegates": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                    "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                     "bundled": true
                 },
                 "detect-indent": {
                     "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+                    "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
                     "bundled": true
                 },
                 "detect-newline": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+                    "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
                     "bundled": true
                 },
                 "dezalgo": {
                     "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+                    "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
                     "bundled": true,
                     "requires": {
                         "asap": "^2.0.0",
@@ -2548,6 +11203,8 @@
                 },
                 "dot-prop": {
                     "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
                     "bundled": true,
                     "requires": {
                         "is-obj": "^1.0.0"
@@ -2555,14 +11212,20 @@
                 },
                 "dotenv": {
                     "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+                    "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
                     "bundled": true
                 },
                 "duplexer3": {
                     "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                    "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
                     "bundled": true
                 },
                 "duplexify": {
                     "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+                    "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
                     "bundled": true,
                     "requires": {
                         "end-of-stream": "^1.0.0",
@@ -2573,6 +11236,8 @@
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -2586,6 +11251,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -2595,6 +11262,8 @@
                 },
                 "ecc-jsbn": {
                     "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+                    "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
                     "bundled": true,
                     "optional": true,
                     "requires": {
@@ -2604,10 +11273,14 @@
                 },
                 "editor": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+                    "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
                     "bundled": true
                 },
                 "encoding": {
                     "version": "0.1.12",
+                    "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                    "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                     "bundled": true,
                     "requires": {
                         "iconv-lite": "~0.4.13"
@@ -2615,6 +11288,8 @@
                 },
                 "end-of-stream": {
                     "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+                    "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "bundled": true,
                     "requires": {
                         "once": "^1.4.0"
@@ -2622,14 +11297,20 @@
                 },
                 "env-paths": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+                    "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
                     "bundled": true
                 },
                 "err-code": {
                     "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                    "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                     "bundled": true
                 },
                 "errno": {
                     "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+                    "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
                     "bundled": true,
                     "requires": {
                         "prr": "~1.0.1"
@@ -2637,6 +11318,8 @@
                 },
                 "es-abstract": {
                     "version": "1.12.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+                    "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
                     "bundled": true,
                     "requires": {
                         "es-to-primitive": "^1.1.1",
@@ -2648,6 +11331,8 @@
                 },
                 "es-to-primitive": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+                    "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
                     "bundled": true,
                     "requires": {
                         "is-callable": "^1.1.4",
@@ -2657,10 +11342,14 @@
                 },
                 "es6-promise": {
                     "version": "4.2.8",
+                    "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+                    "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
                     "bundled": true
                 },
                 "es6-promisify": {
                     "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                    "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                     "bundled": true,
                     "requires": {
                         "es6-promise": "^4.0.3"
@@ -2668,10 +11357,14 @@
                 },
                 "escape-string-regexp": {
                     "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                     "bundled": true
                 },
                 "execa": {
                     "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "bundled": true,
                     "requires": {
                         "cross-spawn": "^5.0.1",
@@ -2685,36 +11378,52 @@
                     "dependencies": {
                         "get-stream": {
                             "version": "3.0.0",
+                            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                             "bundled": true
                         }
                     }
                 },
                 "extend": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
                     "bundled": true
                 },
                 "extsprintf": {
                     "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                    "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
                     "bundled": true
                 },
                 "fast-deep-equal": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
                     "bundled": true
                 },
                 "fast-json-stable-stringify": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+                    "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
                     "bundled": true
                 },
                 "figgy-pudding": {
                     "version": "3.5.1",
+                    "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+                    "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
                     "bundled": true
                 },
                 "find-npm-prefix": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+                    "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
                     "bundled": true
                 },
                 "find-up": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "bundled": true,
                     "requires": {
                         "locate-path": "^2.0.0"
@@ -2722,6 +11431,8 @@
                 },
                 "flush-write-stream": {
                     "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+                    "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
                     "bundled": true,
                     "requires": {
                         "inherits": "^2.0.1",
@@ -2730,6 +11441,8 @@
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -2743,6 +11456,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -2752,10 +11467,14 @@
                 },
                 "forever-agent": {
                     "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
                     "bundled": true
                 },
                 "form-data": {
                     "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+                    "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "bundled": true,
                     "requires": {
                         "asynckit": "^0.4.0",
@@ -2765,6 +11484,8 @@
                 },
                 "from2": {
                     "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+                    "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
                     "bundled": true,
                     "requires": {
                         "inherits": "^2.0.1",
@@ -2773,6 +11494,8 @@
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -2786,6 +11509,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -2795,6 +11520,8 @@
                 },
                 "fs-minipass": {
                     "version": "1.2.6",
+                    "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+                    "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
                     "bundled": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -2802,6 +11529,8 @@
                 },
                 "fs-vacuum": {
                     "version": "1.2.10",
+                    "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+                    "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
@@ -2811,6 +11540,8 @@
                 },
                 "fs-write-stream-atomic": {
                     "version": "1.0.10",
+                    "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+                    "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
@@ -2821,10 +11552,14 @@
                     "dependencies": {
                         "iferr": {
                             "version": "0.1.5",
+                            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+                            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
                             "bundled": true
                         },
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -2838,6 +11573,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -2847,14 +11584,20 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "bundled": true
                 },
                 "function-bind": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
                     "bundled": true
                 },
                 "gauge": {
                     "version": "2.7.4",
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                     "bundled": true,
                     "requires": {
                         "aproba": "^1.0.3",
@@ -2869,10 +11612,14 @@
                     "dependencies": {
                         "aproba": {
                             "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "bundled": true
                         },
                         "string-width": {
                             "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "bundled": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
@@ -2884,10 +11631,14 @@
                 },
                 "genfun": {
                     "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+                    "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
                     "bundled": true
                 },
                 "gentle-fs": {
                     "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.2.1.tgz",
+                    "integrity": "sha512-e7dRgUM5fsS+7wm2oggZpgcRx6sEvJHXujPH5RzgQ1ziQY4+HuVBYsnUzJwJ+C7mjOJN27DjiFy1TaL+TNltow==",
                     "bundled": true,
                     "requires": {
                         "aproba": "^1.1.2",
@@ -2904,20 +11655,28 @@
                     "dependencies": {
                         "aproba": {
                             "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "bundled": true
                         },
                         "iferr": {
                             "version": "0.1.5",
+                            "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+                            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
                             "bundled": true
                         }
                     }
                 },
                 "get-caller-file": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                    "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
                     "bundled": true
                 },
                 "get-stream": {
                     "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
                     "bundled": true,
                     "requires": {
                         "pump": "^3.0.0"
@@ -2925,6 +11684,8 @@
                 },
                 "getpass": {
                     "version": "0.1.7",
+                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                    "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                     "bundled": true,
                     "requires": {
                         "assert-plus": "^1.0.0"
@@ -2932,6 +11693,8 @@
                 },
                 "glob": {
                     "version": "7.1.4",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
                     "bundled": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -2944,6 +11707,8 @@
                 },
                 "global-dirs": {
                     "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+                    "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
                     "bundled": true,
                     "requires": {
                         "ini": "^1.3.4"
@@ -2951,6 +11716,8 @@
                 },
                 "got": {
                     "version": "6.7.1",
+                    "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                    "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                     "bundled": true,
                     "requires": {
                         "create-error-class": "^3.0.0",
@@ -2968,20 +11735,28 @@
                     "dependencies": {
                         "get-stream": {
                             "version": "3.0.0",
+                            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                             "bundled": true
                         }
                     }
                 },
                 "graceful-fs": {
                     "version": "4.2.2",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+                    "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
                     "bundled": true
                 },
                 "har-schema": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                    "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
                     "bundled": true
                 },
                 "har-validator": {
                     "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+                    "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
                     "bundled": true,
                     "requires": {
                         "ajv": "^5.3.0",
@@ -2990,6 +11765,8 @@
                 },
                 "has": {
                     "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
                     "bundled": true,
                     "requires": {
                         "function-bind": "^1.1.1"
@@ -2997,18 +11774,26 @@
                 },
                 "has-flag": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "bundled": true
                 },
                 "has-symbols": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+                    "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
                     "bundled": true
                 },
                 "has-unicode": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+                    "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                     "bundled": true
                 },
                 "hosted-git-info": {
                     "version": "2.8.2",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
+                    "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
                     "bundled": true,
                     "requires": {
                         "lru-cache": "^5.1.1"
@@ -3016,10 +11801,14 @@
                 },
                 "http-cache-semantics": {
                     "version": "3.8.1",
+                    "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+                    "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
                     "bundled": true
                 },
                 "http-proxy-agent": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+                    "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
                     "bundled": true,
                     "requires": {
                         "agent-base": "4",
@@ -3028,6 +11817,8 @@
                 },
                 "http-signature": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "bundled": true,
                     "requires": {
                         "assert-plus": "^1.0.0",
@@ -3037,6 +11828,8 @@
                 },
                 "https-proxy-agent": {
                     "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+                    "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
                     "bundled": true,
                     "requires": {
                         "agent-base": "^4.3.0",
@@ -3045,6 +11838,8 @@
                 },
                 "humanize-ms": {
                     "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                    "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                     "bundled": true,
                     "requires": {
                         "ms": "^2.0.0"
@@ -3052,6 +11847,8 @@
                 },
                 "iconv-lite": {
                     "version": "0.4.23",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
                     "bundled": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
@@ -3059,10 +11856,14 @@
                 },
                 "iferr": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+                    "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
                     "bundled": true
                 },
                 "ignore-walk": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+                    "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                     "bundled": true,
                     "requires": {
                         "minimatch": "^3.0.4"
@@ -3070,18 +11871,26 @@
                 },
                 "import-lazy": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+                    "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
                     "bundled": true
                 },
                 "imurmurhash": {
                     "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                    "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
                     "bundled": true
                 },
                 "infer-owner": {
                     "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+                    "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
                     "bundled": true
                 },
                 "inflight": {
                     "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "bundled": true,
                     "requires": {
                         "once": "^1.3.0",
@@ -3090,14 +11899,20 @@
                 },
                 "inherits": {
                     "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
                     "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+                    "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                     "bundled": true
                 },
                 "init-package-json": {
                     "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+                    "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
                     "bundled": true,
                     "requires": {
                         "glob": "^7.1.1",
@@ -3112,22 +11927,32 @@
                 },
                 "invert-kv": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
                     "bundled": true
                 },
                 "ip": {
                     "version": "1.1.5",
+                    "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                    "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                     "bundled": true
                 },
                 "ip-regex": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+                    "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
                     "bundled": true
                 },
                 "is-callable": {
                     "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+                    "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
                     "bundled": true
                 },
                 "is-ci": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+                    "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
                     "bundled": true,
                     "requires": {
                         "ci-info": "^1.0.0"
@@ -3135,12 +11960,16 @@
                     "dependencies": {
                         "ci-info": {
                             "version": "1.6.0",
+                            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+                            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
                             "bundled": true
                         }
                     }
                 },
                 "is-cidr": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
+                    "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
                     "bundled": true,
                     "requires": {
                         "cidr-regex": "^2.0.10"
@@ -3148,10 +11977,14 @@
                 },
                 "is-date-object": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+                    "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
                     "bundled": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "bundled": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
@@ -3159,6 +11992,8 @@
                 },
                 "is-installed-globally": {
                     "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+                    "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
                     "bundled": true,
                     "requires": {
                         "global-dirs": "^0.1.0",
@@ -3167,14 +12002,20 @@
                 },
                 "is-npm": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+                    "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
                     "bundled": true
                 },
                 "is-obj": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                    "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
                     "bundled": true
                 },
                 "is-path-inside": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+                    "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
                     "bundled": true,
                     "requires": {
                         "path-is-inside": "^1.0.1"
@@ -3182,10 +12023,14 @@
                 },
                 "is-redirect": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                    "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
                     "bundled": true
                 },
                 "is-regex": {
                     "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+                    "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
                     "bundled": true,
                     "requires": {
                         "has": "^1.0.1"
@@ -3193,14 +12038,20 @@
                 },
                 "is-retry-allowed": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                    "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
                     "bundled": true
                 },
                 "is-stream": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                     "bundled": true
                 },
                 "is-symbol": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+                    "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
                     "bundled": true,
                     "requires": {
                         "has-symbols": "^1.0.0"
@@ -3208,47 +12059,79 @@
                 },
                 "is-typedarray": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                    "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
                     "bundled": true
                 },
                 "isarray": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "bundled": true
                 },
                 "isexe": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+                    "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                     "bundled": true
                 },
                 "isstream": {
                     "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                    "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
                     "bundled": true
                 },
                 "jsbn": {
                     "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                    "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                     "bundled": true,
                     "optional": true
                 },
                 "json-parse-better-errors": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+                    "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
                     "bundled": true
                 },
                 "json-schema": {
                     "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                    "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                     "bundled": true
                 },
                 "json-schema-traverse": {
                     "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
                     "bundled": true
                 },
                 "json-stringify-safe": {
                     "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
                     "bundled": true
                 },
                 "jsonparse": {
                     "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+                    "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
                     "bundled": true
+                },
+                "JSONStream": {
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+                    "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+                    "bundled": true,
+                    "requires": {
+                        "jsonparse": "^1.2.0",
+                        "through": ">=2.2.7 <3"
+                    }
                 },
                 "jsprim": {
                     "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                    "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
                     "bundled": true,
                     "requires": {
                         "assert-plus": "1.0.0",
@@ -3259,6 +12142,8 @@
                 },
                 "latest-version": {
                     "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+                    "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
                     "bundled": true,
                     "requires": {
                         "package-json": "^4.0.0"
@@ -3266,10 +12151,14 @@
                 },
                 "lazy-property": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+                    "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
                     "bundled": true
                 },
                 "lcid": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                     "bundled": true,
                     "requires": {
                         "invert-kv": "^1.0.0"
@@ -3277,6 +12166,8 @@
                 },
                 "libcipm": {
                     "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.3.tgz",
+                    "integrity": "sha512-nuIxNtqA+kIkwUiNM/nZ0yPyR7NkSUov6g6mCfFPkYylO1dEovZBL+NZ3axdouS2UOTa8GdnJ7/meSc1/0AIGw==",
                     "bundled": true,
                     "requires": {
                         "bin-links": "^1.1.2",
@@ -3298,6 +12189,8 @@
                 },
                 "libnpm": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
+                    "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
                     "bundled": true,
                     "requires": {
                         "bin-links": "^1.1.2",
@@ -3324,6 +12217,8 @@
                 },
                 "libnpmaccess": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
+                    "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -3334,6 +12229,8 @@
                 },
                 "libnpmconfig": {
                     "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+                    "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
                     "bundled": true,
                     "requires": {
                         "figgy-pudding": "^3.5.1",
@@ -3343,6 +12240,8 @@
                     "dependencies": {
                         "find-up": {
                             "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                             "bundled": true,
                             "requires": {
                                 "locate-path": "^3.0.0"
@@ -3350,6 +12249,8 @@
                         },
                         "locate-path": {
                             "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                             "bundled": true,
                             "requires": {
                                 "p-locate": "^3.0.0",
@@ -3358,6 +12259,8 @@
                         },
                         "p-limit": {
                             "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+                            "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
                             "bundled": true,
                             "requires": {
                                 "p-try": "^2.0.0"
@@ -3365,6 +12268,8 @@
                         },
                         "p-locate": {
                             "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                             "bundled": true,
                             "requires": {
                                 "p-limit": "^2.0.0"
@@ -3372,12 +12277,16 @@
                         },
                         "p-try": {
                             "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                             "bundled": true
                         }
                     }
                 },
                 "libnpmhook": {
                     "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
+                    "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -3388,6 +12297,8 @@
                 },
                 "libnpmorg": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
+                    "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -3398,6 +12309,8 @@
                 },
                 "libnpmpublish": {
                     "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
+                    "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -3413,6 +12326,8 @@
                 },
                 "libnpmsearch": {
                     "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
+                    "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
                     "bundled": true,
                     "requires": {
                         "figgy-pudding": "^3.5.1",
@@ -3422,6 +12337,8 @@
                 },
                 "libnpmteam": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
+                    "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
                     "bundled": true,
                     "requires": {
                         "aproba": "^2.0.0",
@@ -3432,6 +12349,8 @@
                 },
                 "libnpx": {
                     "version": "10.2.0",
+                    "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.0.tgz",
+                    "integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
                     "bundled": true,
                     "requires": {
                         "dotenv": "^5.0.1",
@@ -3446,6 +12365,8 @@
                 },
                 "locate-path": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "bundled": true,
                     "requires": {
                         "p-locate": "^2.0.0",
@@ -3454,6 +12375,8 @@
                 },
                 "lock-verify": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
+                    "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
                     "bundled": true,
                     "requires": {
                         "npm-package-arg": "^6.1.0",
@@ -3462,6 +12385,8 @@
                 },
                 "lockfile": {
                     "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+                    "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
                     "bundled": true,
                     "requires": {
                         "signal-exit": "^3.0.2"
@@ -3469,10 +12394,14 @@
                 },
                 "lodash._baseindexof": {
                     "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+                    "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
                     "bundled": true
                 },
                 "lodash._baseuniq": {
                     "version": "4.6.0",
+                    "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+                    "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
                     "bundled": true,
                     "requires": {
                         "lodash._createset": "~4.0.0",
@@ -3481,14 +12410,20 @@
                 },
                 "lodash._bindcallback": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                    "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
                     "bundled": true
                 },
                 "lodash._cacheindexof": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+                    "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
                     "bundled": true
                 },
                 "lodash._createcache": {
                     "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                    "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
                     "bundled": true,
                     "requires": {
                         "lodash._getnative": "^3.0.0"
@@ -3496,42 +12431,62 @@
                 },
                 "lodash._createset": {
                     "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+                    "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
                     "bundled": true
                 },
                 "lodash._getnative": {
                     "version": "3.9.1",
+                    "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                    "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
                     "bundled": true
                 },
                 "lodash._root": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                    "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
                     "bundled": true
                 },
                 "lodash.clonedeep": {
                     "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+                    "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
                     "bundled": true
                 },
                 "lodash.restparam": {
                     "version": "3.6.1",
+                    "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                    "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
                     "bundled": true
                 },
                 "lodash.union": {
                     "version": "4.6.0",
+                    "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+                    "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
                     "bundled": true
                 },
                 "lodash.uniq": {
                     "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+                    "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
                     "bundled": true
                 },
                 "lodash.without": {
                     "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+                    "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
                     "bundled": true
                 },
                 "lowercase-keys": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+                    "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
                     "bundled": true
                 },
                 "lru-cache": {
                     "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
                     "bundled": true,
                     "requires": {
                         "yallist": "^3.0.2"
@@ -3539,6 +12494,8 @@
                 },
                 "make-dir": {
                     "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+                    "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                     "bundled": true,
                     "requires": {
                         "pify": "^3.0.0"
@@ -3546,6 +12503,8 @@
                 },
                 "make-fetch-happen": {
                     "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.0.tgz",
+                    "integrity": "sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==",
                     "bundled": true,
                     "requires": {
                         "agentkeepalive": "^3.4.1",
@@ -3563,10 +12522,14 @@
                 },
                 "meant": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
+                    "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
                     "bundled": true
                 },
                 "mem": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                    "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
                     "bundled": true,
                     "requires": {
                         "mimic-fn": "^1.0.0"
@@ -3574,10 +12537,14 @@
                 },
                 "mime-db": {
                     "version": "1.35.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+                    "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
                     "bundled": true
                 },
                 "mime-types": {
                     "version": "2.1.19",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+                    "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
                     "bundled": true,
                     "requires": {
                         "mime-db": "~1.35.0"
@@ -3585,10 +12552,14 @@
                 },
                 "mimic-fn": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
                     "bundled": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "bundled": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
@@ -3596,10 +12567,14 @@
                 },
                 "minimist": {
                     "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                     "bundled": true
                 },
                 "minipass": {
                     "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
+                    "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
                     "bundled": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
@@ -3608,12 +12583,16 @@
                     "dependencies": {
                         "yallist": {
                             "version": "3.0.2",
+                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+                            "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
                             "bundled": true
                         }
                     }
                 },
                 "minizlib": {
                     "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+                    "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                     "bundled": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -3621,6 +12600,8 @@
                 },
                 "mississippi": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+                    "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
                     "bundled": true,
                     "requires": {
                         "concat-stream": "^1.5.0",
@@ -3637,6 +12618,8 @@
                 },
                 "mkdirp": {
                     "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "bundled": true,
                     "requires": {
                         "minimist": "0.0.8"
@@ -3644,6 +12627,8 @@
                 },
                 "move-concurrently": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+                    "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
                     "bundled": true,
                     "requires": {
                         "aproba": "^1.1.1",
@@ -3656,20 +12641,28 @@
                     "dependencies": {
                         "aproba": {
                             "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "bundled": true
                         }
                     }
                 },
                 "ms": {
                     "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "bundled": true
                 },
                 "mute-stream": {
                     "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+                    "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
                     "bundled": true
                 },
                 "node-fetch-npm": {
                     "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+                    "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                     "bundled": true,
                     "requires": {
                         "encoding": "^0.1.11",
@@ -3679,6 +12672,8 @@
                 },
                 "node-gyp": {
                     "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.3.tgz",
+                    "integrity": "sha512-z/JdtkFGUm0QaQUusvloyYuGDub3nUbOo5de1Fz57cM++osBTvQatBUSTlF1k/w8vFHPxxXW6zxGvkxXSpaBkQ==",
                     "bundled": true,
                     "requires": {
                         "env-paths": "^1.0.0",
@@ -3696,6 +12691,8 @@
                     "dependencies": {
                         "nopt": {
                             "version": "3.0.6",
+                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                             "bundled": true,
                             "requires": {
                                 "abbrev": "1"
@@ -3703,12 +12700,16 @@
                         },
                         "semver": {
                             "version": "5.3.0",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                            "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                             "bundled": true
                         }
                     }
                 },
                 "nopt": {
                     "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+                    "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "bundled": true,
                     "requires": {
                         "abbrev": "1",
@@ -3717,6 +12718,8 @@
                 },
                 "normalize-package-data": {
                     "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+                    "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
                     "bundled": true,
                     "requires": {
                         "hosted-git-info": "^2.1.4",
@@ -3727,6 +12730,8 @@
                     "dependencies": {
                         "resolve": {
                             "version": "1.10.0",
+                            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+                            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
                             "bundled": true,
                             "requires": {
                                 "path-parse": "^1.0.6"
@@ -3736,6 +12741,8 @@
                 },
                 "npm-audit-report": {
                     "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.2.tgz",
+                    "integrity": "sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==",
                     "bundled": true,
                     "requires": {
                         "cli-table3": "^0.5.0",
@@ -3744,14 +12751,20 @@
                 },
                 "npm-bundled": {
                     "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+                    "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
                     "bundled": true
                 },
                 "npm-cache-filename": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+                    "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
                     "bundled": true
                 },
                 "npm-install-checks": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+                    "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
                     "bundled": true,
                     "requires": {
                         "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -3759,6 +12772,8 @@
                 },
                 "npm-lifecycle": {
                     "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.3.tgz",
+                    "integrity": "sha512-M0QmmqbEHBXxDrmc6X3+eKjW9+F7Edg1ENau92WkYw1sox6wojHzEZJIRm1ItljEiaigZlKL8mXni/4ylAy1Dg==",
                     "bundled": true,
                     "requires": {
                         "byline": "^5.0.0",
@@ -3773,10 +12788,14 @@
                 },
                 "npm-logical-tree": {
                     "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+                    "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
                     "bundled": true
                 },
                 "npm-package-arg": {
                     "version": "6.1.1",
+                    "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+                    "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
                     "bundled": true,
                     "requires": {
                         "hosted-git-info": "^2.7.1",
@@ -3787,6 +12806,8 @@
                 },
                 "npm-packlist": {
                     "version": "1.4.4",
+                    "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+                    "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
                     "bundled": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
@@ -3795,6 +12816,8 @@
                 },
                 "npm-pick-manifest": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
+                    "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
                     "bundled": true,
                     "requires": {
                         "figgy-pudding": "^3.5.1",
@@ -3804,6 +12827,8 @@
                 },
                 "npm-profile": {
                     "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.2.tgz",
+                    "integrity": "sha512-VRsC04pvRH+9cF+PoVh2nTmJjiG21yu59IHpsBpkxk+jaGAV8lxx96G4SDc0jOHAkfWLXbc6kIph3dGAuRnotQ==",
                     "bundled": true,
                     "requires": {
                         "aproba": "^1.1.2 || 2",
@@ -3813,11 +12838,13 @@
                 },
                 "npm-registry-fetch": {
                     "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.0.tgz",
+                    "integrity": "sha512-Jllq35Jag8dtv0M17ue74XtdQTyqKzuAYGiX9mAjOhkmNjib3bBUgK6mUY61+AHnXeSRobQkpY3/xIOS/omptw==",
                     "bundled": true,
                     "requires": {
-                        "JSONStream": "^1.3.4",
                         "bluebird": "^3.5.1",
                         "figgy-pudding": "^3.4.1",
+                        "JSONStream": "^1.3.4",
                         "lru-cache": "^5.1.1",
                         "make-fetch-happen": "^5.0.0",
                         "npm-package-arg": "^6.1.0"
@@ -3825,6 +12852,8 @@
                 },
                 "npm-run-path": {
                     "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                    "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                     "bundled": true,
                     "requires": {
                         "path-key": "^2.0.0"
@@ -3832,10 +12861,14 @@
                 },
                 "npm-user-validate": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+                    "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
                     "bundled": true
                 },
                 "npmlog": {
                     "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+                    "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                     "bundled": true,
                     "requires": {
                         "are-we-there-yet": "~1.1.2",
@@ -3846,22 +12879,32 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                     "bundled": true
                 },
                 "oauth-sign": {
                     "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
                     "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "bundled": true
                 },
                 "object-keys": {
                     "version": "1.0.12",
+                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+                    "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
                     "bundled": true
                 },
                 "object.getownpropertydescriptors": {
                     "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+                    "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
                     "bundled": true,
                     "requires": {
                         "define-properties": "^1.1.2",
@@ -3870,6 +12913,8 @@
                 },
                 "once": {
                     "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "bundled": true,
                     "requires": {
                         "wrappy": "1"
@@ -3877,14 +12922,20 @@
                 },
                 "opener": {
                     "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+                    "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
                     "bundled": true
                 },
                 "os-homedir": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "bundled": true
                 },
                 "os-locale": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "bundled": true,
                     "requires": {
                         "execa": "^0.7.0",
@@ -3894,10 +12945,14 @@
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                    "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                     "bundled": true
                 },
                 "osenv": {
                     "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+                    "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                     "bundled": true,
                     "requires": {
                         "os-homedir": "^1.0.0",
@@ -3906,10 +12961,14 @@
                 },
                 "p-finally": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                    "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                     "bundled": true
                 },
                 "p-limit": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+                    "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
                     "bundled": true,
                     "requires": {
                         "p-try": "^1.0.0"
@@ -3917,6 +12976,8 @@
                 },
                 "p-locate": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "bundled": true,
                     "requires": {
                         "p-limit": "^1.1.0"
@@ -3924,10 +12985,14 @@
                 },
                 "p-try": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
                     "bundled": true
                 },
                 "package-json": {
                     "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+                    "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                     "bundled": true,
                     "requires": {
                         "got": "^6.7.1",
@@ -3938,6 +13003,8 @@
                 },
                 "pacote": {
                     "version": "9.5.8",
+                    "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.8.tgz",
+                    "integrity": "sha512-0Tl8Oi/K0Lo4MZmH0/6IsT3gpGf9eEAznLXEQPKgPq7FscnbUOyopnVpwXlnQdIbCUaojWy1Wd7VMyqfVsRrIw==",
                     "bundled": true,
                     "requires": {
                         "bluebird": "^3.5.3",
@@ -3973,6 +13040,8 @@
                     "dependencies": {
                         "minipass": {
                             "version": "2.3.5",
+                            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+                            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
@@ -3983,6 +13052,8 @@
                 },
                 "parallel-transform": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+                    "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
                     "bundled": true,
                     "requires": {
                         "cyclist": "~0.2.2",
@@ -3992,6 +13063,8 @@
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -4005,6 +13078,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -4014,46 +13089,68 @@
                 },
                 "path-exists": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "bundled": true
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "bundled": true
                 },
                 "path-is-inside": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+                    "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
                     "bundled": true
                 },
                 "path-key": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                     "bundled": true
                 },
                 "path-parse": {
                     "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+                    "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
                     "bundled": true
                 },
                 "performance-now": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+                    "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
                     "bundled": true
                 },
                 "pify": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "bundled": true
                 },
                 "prepend-http": {
                     "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                    "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                     "bundled": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                     "bundled": true
                 },
                 "promise-inflight": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+                    "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
                     "bundled": true
                 },
                 "promise-retry": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+                    "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                     "bundled": true,
                     "requires": {
                         "err-code": "^1.0.0",
@@ -4062,12 +13159,16 @@
                     "dependencies": {
                         "retry": {
                             "version": "0.10.1",
+                            "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+                            "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
                             "bundled": true
                         }
                     }
                 },
                 "promzard": {
                     "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+                    "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
                     "bundled": true,
                     "requires": {
                         "read": "1"
@@ -4075,10 +13176,14 @@
                 },
                 "proto-list": {
                     "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                    "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
                     "bundled": true
                 },
                 "protoduck": {
                     "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+                    "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
                     "bundled": true,
                     "requires": {
                         "genfun": "^5.0.0"
@@ -4086,18 +13191,26 @@
                 },
                 "prr": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+                    "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
                     "bundled": true
                 },
                 "pseudomap": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                    "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                     "bundled": true
                 },
                 "psl": {
                     "version": "1.1.29",
+                    "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+                    "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
                     "bundled": true
                 },
                 "pump": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
                     "bundled": true,
                     "requires": {
                         "end-of-stream": "^1.1.0",
@@ -4106,6 +13219,8 @@
                 },
                 "pumpify": {
                     "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+                    "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
                     "bundled": true,
                     "requires": {
                         "duplexify": "^3.6.0",
@@ -4115,6 +13230,8 @@
                     "dependencies": {
                         "pump": {
                             "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
                             "bundled": true,
                             "requires": {
                                 "end-of-stream": "^1.1.0",
@@ -4125,18 +13242,26 @@
                 },
                 "punycode": {
                     "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                     "bundled": true
                 },
                 "qrcode-terminal": {
                     "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+                    "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
                     "bundled": true
                 },
                 "qs": {
                     "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
                     "bundled": true
                 },
                 "query-string": {
                     "version": "6.8.2",
+                    "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+                    "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
                     "bundled": true,
                     "requires": {
                         "decode-uri-component": "^0.2.0",
@@ -4146,10 +13271,14 @@
                 },
                 "qw": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+                    "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
                     "bundled": true
                 },
                 "rc": {
                     "version": "1.2.7",
+                    "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+                    "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
                     "bundled": true,
                     "requires": {
                         "deep-extend": "^0.5.1",
@@ -4160,12 +13289,16 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "bundled": true
                         }
                     }
                 },
                 "read": {
                     "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+                    "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
                     "bundled": true,
                     "requires": {
                         "mute-stream": "~0.0.4"
@@ -4173,6 +13306,8 @@
                 },
                 "read-cmd-shim": {
                     "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.4.tgz",
+                    "integrity": "sha512-Pqpl3qJ/QdOIjRYA0q5DND/gLvGOfpIz/fYVDGYpOXfW/lFrIttmLsBnd6IkyK10+JHU9zhsaudfvrQTBB9YFQ==",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.2"
@@ -4180,6 +13315,8 @@
                 },
                 "read-installed": {
                     "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+                    "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
                     "bundled": true,
                     "requires": {
                         "debuglog": "^1.0.1",
@@ -4193,6 +13330,8 @@
                 },
                 "read-package-json": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.0.tgz",
+                    "integrity": "sha512-KLhu8M1ZZNkMcrq1+0UJbR8Dii8KZUqB0Sha4mOx/bknfKI/fyrQVrG/YIt2UOtG667sD8+ee4EXMM91W9dC+A==",
                     "bundled": true,
                     "requires": {
                         "glob": "^7.1.1",
@@ -4204,6 +13343,8 @@
                 },
                 "read-package-tree": {
                     "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+                    "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
                     "bundled": true,
                     "requires": {
                         "read-package-json": "^2.0.0",
@@ -4213,6 +13354,8 @@
                 },
                 "readable-stream": {
                     "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+                    "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
                     "bundled": true,
                     "requires": {
                         "inherits": "^2.0.3",
@@ -4222,6 +13365,8 @@
                 },
                 "readdir-scoped-modules": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+                    "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
                     "bundled": true,
                     "requires": {
                         "debuglog": "^1.0.1",
@@ -4232,6 +13377,8 @@
                 },
                 "registry-auth-token": {
                     "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+                    "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
                     "bundled": true,
                     "requires": {
                         "rc": "^1.1.6",
@@ -4240,6 +13387,8 @@
                 },
                 "registry-url": {
                     "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+                    "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                     "bundled": true,
                     "requires": {
                         "rc": "^1.0.1"
@@ -4247,6 +13396,8 @@
                 },
                 "request": {
                     "version": "2.88.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "bundled": true,
                     "requires": {
                         "aws-sign2": "~0.7.0",
@@ -4273,22 +13424,32 @@
                 },
                 "require-directory": {
                     "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                    "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
                     "bundled": true
                 },
                 "require-main-filename": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                     "bundled": true
                 },
                 "resolve-from": {
                     "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
                     "bundled": true
                 },
                 "retry": {
                     "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+                    "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
                     "bundled": true
                 },
                 "rimraf": {
                     "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                     "bundled": true,
                     "requires": {
                         "glob": "^7.1.3"
@@ -4296,6 +13457,8 @@
                 },
                 "run-queue": {
                     "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+                    "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
                     "bundled": true,
                     "requires": {
                         "aproba": "^1.1.1"
@@ -4303,24 +13466,34 @@
                     "dependencies": {
                         "aproba": {
                             "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                             "bundled": true
                         }
                     }
                 },
                 "safe-buffer": {
                     "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                     "bundled": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+                    "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                     "bundled": true
                 },
                 "semver": {
                     "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "bundled": true
                 },
                 "semver-diff": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+                    "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
                     "bundled": true,
                     "requires": {
                         "semver": "^5.0.3"
@@ -4328,10 +13501,14 @@
                 },
                 "set-blocking": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "bundled": true
                 },
                 "sha": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
+                    "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.2"
@@ -4339,6 +13516,8 @@
                 },
                 "shebang-command": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                     "bundled": true,
                     "requires": {
                         "shebang-regex": "^1.0.0"
@@ -4346,26 +13525,38 @@
                 },
                 "shebang-regex": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                     "bundled": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "bundled": true
                 },
                 "slash": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                    "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
                     "bundled": true
                 },
                 "slide": {
                     "version": "1.1.6",
+                    "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                    "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
                     "bundled": true
                 },
                 "smart-buffer": {
                     "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+                    "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
                     "bundled": true
                 },
                 "socks": {
                     "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+                    "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
                     "bundled": true,
                     "requires": {
                         "ip": "^1.1.5",
@@ -4374,6 +13565,8 @@
                 },
                 "socks-proxy-agent": {
                     "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+                    "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
                     "bundled": true,
                     "requires": {
                         "agent-base": "~4.2.1",
@@ -4382,6 +13575,8 @@
                     "dependencies": {
                         "agent-base": {
                             "version": "4.2.1",
+                            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+                            "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
                             "bundled": true,
                             "requires": {
                                 "es6-promisify": "^5.0.0"
@@ -4391,10 +13586,14 @@
                 },
                 "sorted-object": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+                    "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
                     "bundled": true
                 },
                 "sorted-union-stream": {
                     "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+                    "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
                     "bundled": true,
                     "requires": {
                         "from2": "^1.3.0",
@@ -4403,6 +13602,8 @@
                     "dependencies": {
                         "from2": {
                             "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+                            "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
                             "bundled": true,
                             "requires": {
                                 "inherits": "~2.0.1",
@@ -4411,10 +13612,14 @@
                         },
                         "isarray": {
                             "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                             "bundled": true
                         },
                         "readable-stream": {
                             "version": "1.1.14",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -4425,12 +13630,16 @@
                         },
                         "string_decoder": {
                             "version": "0.10.31",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                             "bundled": true
                         }
                     }
                 },
                 "spdx-correct": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+                    "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
                     "bundled": true,
                     "requires": {
                         "spdx-expression-parse": "^3.0.0",
@@ -4439,10 +13648,14 @@
                 },
                 "spdx-exceptions": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+                    "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
                     "bundled": true
                 },
                 "spdx-expression-parse": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+                    "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
                     "bundled": true,
                     "requires": {
                         "spdx-exceptions": "^2.1.0",
@@ -4451,14 +13664,20 @@
                 },
                 "spdx-license-ids": {
                     "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+                    "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
                     "bundled": true
                 },
                 "split-on-first": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+                    "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
                     "bundled": true
                 },
                 "sshpk": {
                     "version": "1.14.2",
+                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+                    "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
                     "bundled": true,
                     "requires": {
                         "asn1": "~0.2.3",
@@ -4474,6 +13693,8 @@
                 },
                 "ssri": {
                     "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+                    "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
                     "bundled": true,
                     "requires": {
                         "figgy-pudding": "^3.5.1"
@@ -4481,6 +13702,8 @@
                 },
                 "stream-each": {
                     "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+                    "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
                     "bundled": true,
                     "requires": {
                         "end-of-stream": "^1.1.0",
@@ -4489,6 +13712,8 @@
                 },
                 "stream-iterate": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+                    "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
                     "bundled": true,
                     "requires": {
                         "readable-stream": "^2.1.5",
@@ -4497,6 +13722,8 @@
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -4510,6 +13737,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -4519,14 +13748,29 @@
                 },
                 "stream-shift": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                    "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                     "bundled": true
                 },
                 "strict-uri-encode": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+                    "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
                     "bundled": true
+                },
+                "string_decoder": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+                    "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
                 },
                 "string-width": {
                     "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "bundled": true,
                     "requires": {
                         "is-fullwidth-code-point": "^2.0.0",
@@ -4535,14 +13779,20 @@
                     "dependencies": {
                         "ansi-regex": {
                             "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                             "bundled": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                             "bundled": true
                         },
                         "strip-ansi": {
                             "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "bundled": true,
                             "requires": {
                                 "ansi-regex": "^3.0.0"
@@ -4550,19 +13800,16 @@
                         }
                     }
                 },
-                "string_decoder": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
                 "stringify-package": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
+                    "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
                     "bundled": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "bundled": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
@@ -4570,14 +13817,20 @@
                 },
                 "strip-eof": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                    "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                     "bundled": true
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                     "bundled": true
                 },
                 "supports-color": {
                     "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "bundled": true,
                     "requires": {
                         "has-flag": "^3.0.0"
@@ -4585,6 +13838,8 @@
                 },
                 "tar": {
                     "version": "4.4.10",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+                    "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
                     "bundled": true,
                     "requires": {
                         "chownr": "^1.1.1",
@@ -4598,6 +13853,8 @@
                     "dependencies": {
                         "minipass": {
                             "version": "2.3.5",
+                            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+                            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
@@ -4606,12 +13863,16 @@
                         },
                         "yallist": {
                             "version": "3.0.3",
+                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                            "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                             "bundled": true
                         }
                     }
                 },
                 "term-size": {
                     "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+                    "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
                     "bundled": true,
                     "requires": {
                         "execa": "^0.7.0"
@@ -4619,14 +13880,20 @@
                 },
                 "text-table": {
                     "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+                    "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
                     "bundled": true
                 },
                 "through": {
                     "version": "2.3.8",
+                    "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                    "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
                     "bundled": true
                 },
                 "through2": {
                     "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                     "bundled": true,
                     "requires": {
                         "readable-stream": "^2.1.5",
@@ -4635,6 +13902,8 @@
                     "dependencies": {
                         "readable-stream": {
                             "version": "2.3.6",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                             "bundled": true,
                             "requires": {
                                 "core-util-is": "~1.0.0",
@@ -4648,6 +13917,8 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                             "bundled": true,
                             "requires": {
                                 "safe-buffer": "~5.1.0"
@@ -4657,14 +13928,20 @@
                 },
                 "timed-out": {
                     "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                    "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
                     "bundled": true
                 },
                 "tiny-relative-date": {
                     "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
+                    "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
                     "bundled": true
                 },
                 "tough-cookie": {
                     "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "bundled": true,
                     "requires": {
                         "psl": "^1.1.24",
@@ -4673,6 +13950,8 @@
                 },
                 "tunnel-agent": {
                     "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "bundled": true,
                     "requires": {
                         "safe-buffer": "^5.0.1"
@@ -4680,23 +13959,33 @@
                 },
                 "tweetnacl": {
                     "version": "0.14.5",
+                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                    "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                     "bundled": true,
                     "optional": true
                 },
                 "typedarray": {
                     "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                    "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                     "bundled": true
                 },
                 "uid-number": {
                     "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+                    "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
                     "bundled": true
                 },
                 "umask": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+                    "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
                     "bundled": true
                 },
                 "unique-filename": {
                     "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+                    "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
                     "bundled": true,
                     "requires": {
                         "unique-slug": "^2.0.0"
@@ -4704,6 +13993,8 @@
                 },
                 "unique-slug": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+                    "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                     "bundled": true,
                     "requires": {
                         "imurmurhash": "^0.1.4"
@@ -4711,6 +14002,8 @@
                 },
                 "unique-string": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+                    "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                     "bundled": true,
                     "requires": {
                         "crypto-random-string": "^1.0.0"
@@ -4718,14 +14011,20 @@
                 },
                 "unpipe": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                    "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
                     "bundled": true
                 },
                 "unzip-response": {
                     "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+                    "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
                     "bundled": true
                 },
                 "update-notifier": {
                     "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+                    "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
                     "bundled": true,
                     "requires": {
                         "boxen": "^1.2.1",
@@ -4742,6 +14041,8 @@
                 },
                 "url-parse-lax": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                     "bundled": true,
                     "requires": {
                         "prepend-http": "^1.0.1"
@@ -4749,14 +14050,20 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "bundled": true
                 },
                 "util-extend": {
                     "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+                    "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
                     "bundled": true
                 },
                 "util-promisify": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+                    "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
                     "bundled": true,
                     "requires": {
                         "object.getownpropertydescriptors": "^2.0.3"
@@ -4764,10 +14071,14 @@
                 },
                 "uuid": {
                     "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
                     "bundled": true
                 },
                 "validate-npm-package-license": {
                     "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+                    "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
                     "bundled": true,
                     "requires": {
                         "spdx-correct": "^3.0.0",
@@ -4776,6 +14087,8 @@
                 },
                 "validate-npm-package-name": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+                    "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
                     "bundled": true,
                     "requires": {
                         "builtins": "^1.0.3"
@@ -4783,6 +14096,8 @@
                 },
                 "verror": {
                     "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                    "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                     "bundled": true,
                     "requires": {
                         "assert-plus": "^1.0.0",
@@ -4792,6 +14107,8 @@
                 },
                 "wcwidth": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+                    "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
                     "bundled": true,
                     "requires": {
                         "defaults": "^1.0.3"
@@ -4799,6 +14116,8 @@
                 },
                 "which": {
                     "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                     "bundled": true,
                     "requires": {
                         "isexe": "^2.0.0"
@@ -4806,10 +14125,14 @@
                 },
                 "which-module": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
                     "bundled": true
                 },
                 "wide-align": {
                     "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                    "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                     "bundled": true,
                     "requires": {
                         "string-width": "^1.0.2"
@@ -4817,6 +14140,8 @@
                     "dependencies": {
                         "string-width": {
                             "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "bundled": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
@@ -4828,6 +14153,8 @@
                 },
                 "widest-line": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+                    "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
                     "bundled": true,
                     "requires": {
                         "string-width": "^2.1.1"
@@ -4835,6 +14162,8 @@
                 },
                 "worker-farm": {
                     "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+                    "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
                     "bundled": true,
                     "requires": {
                         "errno": "~0.1.7"
@@ -4842,6 +14171,8 @@
                 },
                 "wrap-ansi": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                     "bundled": true,
                     "requires": {
                         "string-width": "^1.0.1",
@@ -4850,6 +14181,8 @@
                     "dependencies": {
                         "string-width": {
                             "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "bundled": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
@@ -4861,10 +14194,14 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                     "bundled": true
                 },
                 "write-file-atomic": {
                     "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+                    "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
                     "bundled": true,
                     "requires": {
                         "graceful-fs": "^4.1.11",
@@ -4874,22 +14211,32 @@
                 },
                 "xdg-basedir": {
                     "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+                    "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
                     "bundled": true
                 },
                 "xtend": {
                     "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                     "bundled": true
                 },
                 "y18n": {
                     "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
                     "bundled": true
                 },
                 "yallist": {
                     "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
                     "bundled": true
                 },
                 "yargs": {
                     "version": "11.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+                    "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "bundled": true,
                     "requires": {
                         "cliui": "^4.0.0",
@@ -4908,12 +14255,16 @@
                     "dependencies": {
                         "y18n": {
                             "version": "3.2.1",
+                            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                             "bundled": true
                         }
                     }
                 },
                 "yargs-parser": {
                     "version": "9.0.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+                    "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                     "bundled": true,
                     "requires": {
                         "camelcase": "^4.1.0"
@@ -5348,6 +14699,14 @@
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
         },
+        "string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "string-width": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -5356,14 +14715,6 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.0"
-            }
-        },
-        "string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "requires": {
-                "safe-buffer": "~5.2.0"
             }
         },
         "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -197,6 +197,11 @@
                     "default": true,
                     "description": "Automatically close template gallery when selecting a template.",
                     "type": "boolean"
+                },
+                "mjml.updateOnSeparateFileChange": {
+                    "default": true,
+                    "description": "Automatically update preview when editing a different file.",
+                    "type": "boolean"
                 }
             }
         },
@@ -319,13 +324,13 @@
         "@types/file-url": "^2.0.0",
         "@types/js-beautify": "^1.8.0",
         "@types/mime": "^2.0.0",
-        "@types/node-fetch": "^2.1.2",
         "@types/node": "*",
+        "@types/node-fetch": "^2.1.2",
         "@types/nodemailer": "^4.6.5",
         "@types/npm": "^2.0.29",
         "highlight.js": "^9.13.1",
-        "markdown-it-anchor": "^5.0.2",
         "markdown-it": "^8.4.2",
+        "markdown-it-anchor": "^5.0.2",
         "typescript": "^3.1.3",
         "vscode": "^1.1.21"
     },

--- a/package.json
+++ b/package.json
@@ -1,24 +1,23 @@
 {
     "name": "vscode-mjml",
-    "displayName": "MJML",
+    "displayName": "MJML (non-official fork)",
     "description": "MJML preview, lint, compile for Visual Studio Code.",
-    "version": "1.0.4",
-    "publisher": "mjmlio",
+    "version": "0.0.1",
+    "publisher": "DanielKnights",
     "license": "MIT",
     "readme": "README.md",
     "icon": "images/icon.png",
     "author": {
-        "name": "MJML",
-        "email": "cedric@derniercri.io",
-        "url": "https://mjml.io/"
+        "name": "Daniel Knights",
+        "email": "danknights95@gmail.com"
     },
-    "homepage": "https://github.com/mjmlio/vscode-mjml#readme",
+    "homepage": "https://github.com/Daniel-Knights/vscode-mjml#readme",
     "repository": {
         "type": "git",
-        "url": "https://github.com/mjmlio/vscode-mjml"
+        "url": "https://github.com/Daniel-Knights/vscode-mjml"
     },
     "bugs": {
-        "url": "https://github.com/mjmlio/vscode-mjml/issues"
+        "url": "https://github.com/Daniel-Knights/vscode-mjml/issues"
     },
     "galleryBanner": {
         "color": "#f45e43",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -50,17 +50,29 @@ export default class Preview {
             }),
 
             workspace.onDidChangeTextDocument((event?: TextDocumentChangeEvent) => {
+                if (!event) return
+
                 if (
-                    event &&
-                    this.previewOpen &&
-                    workspace.getConfiguration('mjml').updateWhenTyping
-                ) {
+                    event.document.fileName !== this.openedDocuments[0] &&
+                    !workspace.getConfiguration('mjml').updateOnSeparateFileChange
+                )
+                    return
+
+                if (this.previewOpen && workspace.getConfiguration('mjml').updateWhenTyping) {
                     this.displayWebView(event.document)
                 }
             }),
 
             workspace.onDidSaveTextDocument((document?: TextDocument) => {
-                if (document && this.previewOpen) {
+                if (!document) return
+
+                if (
+                    document.fileName !== this.openedDocuments[0] &&
+                    !workspace.getConfiguration('mjml').updateOnSeparateFileChange
+                )
+                    return
+
+                if (this.previewOpen) {
                     this.displayWebView(document)
                 }
             }),


### PR DESCRIPTION
# Why

As a user of this extension, it's frustrating to edit a separate MJML file and have the previewer switch automatically.

# How

- Adding a config option that would allow turning this off.
- If the option is set to `false` check that the file being edited is the same one that opened the previewer before updating the preview.