### PR TITLE
Allow to preview partial MJML files

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -127,7 +127,7 @@ export default class Preview {
 
     private getContent(document: TextDocument): string {
         const html: string = mjmlToHtml(
-            document.getText(),
+            this.wrapInMjmlTemplate(document.getText()),
             false,
             false,
             document.uri.fsPath,
@@ -141,6 +141,14 @@ export default class Preview {
         }
 
         return this.error("Active editor doesn't show a MJML document.")
+    }
+
+    private wrapInMjmlTemplate(documentText:string): string {
+        if(documentText.includes("<mjml>"))
+        {
+            return documentText;
+        }        
+        return "<mjml><mj-body>" + documentText + "</mj-body></mjml>";
     }
 
     private setBackgroundColor(html: string): string {


### PR DESCRIPTION
Previous version only allow to preview complete and well-formed MJML files (<mjml><mjml-body>....</mjml-body></mjml>). 
This version allows also to preview partial MJML files (<mjml-section>...</mjml-section>) to be able to create dynamic layouts splitting shared headers/footers in different files and include them in run-time.

`<mj-section>
    <mj-column>
            <mj-text>THIS IS A PREVIEW OF A PARTIAL MJML FILE !!!!</mj-text>
    </mj-column>
</mj-section>`