### PR TITLE
Add a setting for custom config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The following command is available:
 | `mjml.templateGallery` | `false` | Show the template gallery instead of quick pick. |
 | `mjml.templateGalleryAutoClose` | `true` | Automatically close template gallery when selecting a template. |
 | `mjml.switchOnSeparateFileChange` | `true` | Automatically switch previews when editing a different file. |
+| `mjml.mjmlConfigPath` | ` ` | The path or directory of the .mjmlconfig (or .mjmlconfig.js) file (for custom components use) |
 
 
 ## Snippets

--- a/package.json
+++ b/package.json
@@ -202,6 +202,11 @@
           "default": true,
           "description": "Automatically switch previews when editing a different file.",
           "type": "boolean"
+        },
+        "mjml.mjmlConfigPath": {
+          "default": "",
+          "description": "The path or directory of the .mjmlconfig (or .mjmlconfig.js) file (for custom components use)",
+          "type": "string"
         }
       }
     },

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -84,6 +84,7 @@ export default class Linter {
                 false,
                 getPath(),
                 'strict',
+                workspace.getConfiguration('mjml').mjmlConfigPath
             ).errors
 
             if (errors && errors[0]) {

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -135,6 +135,7 @@ export default class Preview {
             false,
             document.uri.fsPath,
             'skip',
+            workspace.getConfiguration('mjml').mjmlConfigPath
         ).html
 
         if (html) {


### PR DESCRIPTION
Add `mjmlConfigPath` setting mimicking the cli option: https://github.com/mjmlio/mjml?tab=readme-ov-file#inside-nodejs

With this you can set the config to be a js file (`.mjmlconfig.js`) and thus enable custom templates and preprocessors.

After reading https://thoughtbot.com/blog/building-templated-emails-with-mjml I thought "this is the solution for using handlebars in mjml!!" But when I tried it the vscode extension didn't pick up the `.mjmlconfig.js` file at all. 

Now while I do think mjml should pick that file up if it is available, not just `.mjmlconfig`, I don't think there should be anything stopping this extension to allow you to set your mjml config file directly. I'm sure it would be useful to lots of people for other purposes too. 

I've also published this code in the marketplace https://marketplace.visualstudio.com/items?itemName=IvanKeirn.vscode-mjml-custom-path to demonstrate its feasibility. 