### PR TITLE
fix: use correct org name in readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,11 @@ Please see the [Nodemailer](https://nodemailer.com) documentation for more infor
 
 ## Issues
 
-Submit the [issues](https://github.com/mjml/vscode-mjml/issues) if you find any bug or have any suggestion.
+Submit the [issues](https://github.com/mjmlio/vscode-mjml/issues) if you find any bug or have any suggestion.
 
 ## Contribution
 
-Fork the [repo](https://github.com/mjml/vscode-mjml) and submit pull requests.
+Fork the [repo](https://github.com/mjmlio/vscode-mjml) and submit pull requests.
 
 ## Contributors
 


### PR DESCRIPTION
fix typo: mjml -> mjmlio