### PR TITLE
bugfix(include): implement opt-in include allowlisting per MJML 5 (Fixes: #76)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ yarn.lock
 
 .env
 .idea/**
+
+examples/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the "mjml" extension will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-### [2.3.1] (2026-05-07)
+### [3.0.0] (2026-05-07)
 
 #### BREAKING CHANGE
 The MJML 5.1.0 update addressed CVE-2025-67898 (arbitrary file inclusion vulnerability) by flipping `ignoreIncludes` default from `false` to `true`. This extension now aligns with MJML's secure-by-default model therefore `mj-include` processing is now opt-in by default via `mjml.allowIncludes` settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,19 @@
 All notable changes to the "mjml" extension will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+### [2.3.1] (2026-05-07)
+
+#### BREAKING CHANGE
+The MJML 5.1.0 update addressed CVE-2025-67898 (arbitrary file inclusion vulnerability) by flipping `ignoreIncludes` default from `false` to `true`. This extension now aligns with MJML's secure-by-default model therefore `mj-include` processing is now opt-in by default via `mjml.allowIncludes` settings.
+
+#### Other changes
+- [update] MJML to v5.2.0
+- [security] `mj-include` is now opt-in via new `mjml.allowIncludes` setting (default: `false`) to align with MJML 5 secure defaults
+- [fix] Added `mjml.includePath` setting to allowlist include directories outside the template base when includes are enabled
+
 ### [2.3.0] (2026-04-28)
 
 - [update] MJML to v5.1.0
-- [fix] `mj-include` now works correctly (MJML 5 changed the default for `ignoreIncludes` to `true`; explicitly restored to `false` to preserve existing behaviour)
 - [chore] Removed stale `mjml-migrate` type declaration (package removed in MJML 5)
 - [new] `.mjmlconfig` files are now automatically recognised as JSON in the editor (resolves [#21](https://github.com/mjmlio/vscode-mjml/issues/21))
 - [fix] Preview no longer breaks when an HTML comment appears before the opening `<mjml>` tag (resolves [#57](https://github.com/mjmlio/vscode-mjml/issues/57))

--- a/README.md
+++ b/README.md
@@ -47,33 +47,69 @@ The following command is available:
 
 ## Settings
 
-| Name                              | Default   | Description                                                                                                       |
-| --------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
-| `mjml.autoPreview`                | `false`   | Automatically update preview when switching between MJML documents.                                               |
-| `mjml.beautifyHtmlOutput`         | `false`   | Beautify HTML output. (Works when `mjml.minifyHtmlOutput` aren't enabled.)                                        |
-| `mjml.beautify`                   | `{}`      | Prettier options for beautifying MJML. (Priority: .prettierrc > mjml.beautify > defaults). See [Prettier options](https://prettier.io/docs/en/options.html). |
-| `mjml.exportType`                 | `.html`   | Specifies the file type of the output file.                                                                       |
-| `mjml.keepComments`               | `true`    | Keep custom comments in HTML output when exporting MJML files.                                                    |
-| `mjml.lintEnable`                 | `true`    | Enable/disable MJML linter (requires restart).                                                                    |
-| `mjml.lintWhenTyping`             | `true`    | Whether the linter is run on type or on save.                                                                     |
-| `mjml.mailFromName`               | ` `       | Sender name.                                                                                                      |
-| `mjml.mailRecipients`             | ` `       | Comma separated list of recipients email addresses.                                                               |
-| `mjml.mailSender`                 | ` `       | Sender email address. (Mailjet: must be a verified sender.)                                                       |
-| `mjml.mailSubject`                | ` `       | Email subject.                                                                                                    |
-| `mjml.mailer`                     | `mailjet` | Send email with Nodemailer or Mailjet. Possible values are 'nodemailer' and 'mailjet'. See examples of [Nodemailer config](https://github.com/mjmlio/vscode-mjml?tab=readme-ov-file#nodemailer-configuration)                           |
-| `mjml.mailjetAPIKey`              | ` `       | Mailjet API Key.                                                                                                  |
-| `mjml.mailjetAPISecret`           | ` `       | Mailjet API Secret.                                                                                               |
-| `mjml.minifyHtmlOutput`           | `true`    | Minify HTML output.                                                                                               |
-| `mjml.nodemailer`                 | `{}`      | Nodemailer configuration. Please see the [Nodemailer](https://nodemailer.com) documentation for more information. |
-| `mjml.preserveFocus`              | `true`    | Preserve focus of Text Editor after preview open.                                                                 |
-| `mjml.updateWhenTyping`           | `true`    | Update preview when typing.                                                                                       |
-| `mjml.previewBackgroundColor`     | `#FFFFFF` | Preview background color.                                                                                         |
-| `mjml.autoClosePreview`           | `true`    | Automatically close preview when all open MJML documents have been closed.                                        |
-| `mjml.showSaveDialog`             | `false`   | Show the save as dialog instead of input box.                                                                     |
-| `mjml.templateGallery`            | `false`   | Show the template gallery instead of quick pick.                                                                  |
-| `mjml.templateGalleryAutoClose`   | `true`    | Automatically close template gallery when selecting a template.                                                   |
-| `mjml.switchOnSeparateFileChange` | `true`    | Automatically switch previews when editing a different file.                                                      |
-| `mjml.mjmlConfigPath`             | ` `       | The path or directory of the .mjmlconfig (or .mjmlconfig.js) file (for custom components use)                     |
+| Name                              | Default   | Description                                                                                                                                                                                                   |
+| --------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mjml.autoClosePreview`           | `true`    | Automatically close preview when all open MJML documents have been closed.                                                                                                                                    |
+| `mjml.allowIncludes`              | `false`   | Enable `mj-include` processing. Disabled by default for security.                                                                                                                                             |
+| `mjml.autoPreview`                | `false`   | Automatically update preview when switching between MJML documents.                                                                                                                                           |
+| `mjml.beautify`                   | `{}`      | Prettier options for beautifying MJML. (Priority: .prettierrc > mjml.beautify > defaults). See [Prettier options](https://prettier.io/docs/en/options.html).                                                  |
+| `mjml.beautifyHtmlOutput`         | `false`   | Beautify HTML output. (Works when `mjml.minifyHtmlOutput` aren't enabled.)                                                                                                                                    |
+| `mjml.exportType`                 | `.html`   | Specifies the file type of the output file.                                                                                                                                                                   |
+| `mjml.includePath`                | `[]`      | Additional directories to allow for `<mj-include>` lookups when `mjml.allowIncludes` is enabled. Supports absolute paths, or paths relative to the workspace root.                                            |
+| `mjml.keepComments`               | `true`    | Keep custom comments in HTML output when exporting MJML files.                                                                                                                                                |
+| `mjml.lintEnable`                 | `true`    | Enable/disable MJML linter (requires restart).                                                                                                                                                                |
+| `mjml.lintWhenTyping`             | `true`    | Whether the linter is run on type or on save.                                                                                                                                                                 |
+| `mjml.mailer`                     | `mailjet` | Send email with Nodemailer or Mailjet. Possible values are 'nodemailer' and 'mailjet'. See examples of [Nodemailer config](https://github.com/mjmlio/vscode-mjml?tab=readme-ov-file#nodemailer-configuration) |
+| `mjml.mailFromName`               | ` `       | Sender name.                                                                                                                                                                                                  |
+| `mjml.mailjetAPIKey`              | ` `       | Mailjet API Key.                                                                                                                                                                                              |
+| `mjml.mailjetAPISecret`           | ` `       | Mailjet API Secret.                                                                                                                                                                                           |
+| `mjml.mailRecipients`             | ` `       | Comma separated list of recipients email addresses.                                                                                                                                                           |
+| `mjml.mailSender`                 | ` `       | Sender email address. (Mailjet: must be a verified sender.)                                                                                                                                                   |
+| `mjml.mailSubject`                | ` `       | Email subject.                                                                                                                                                                                                |
+| `mjml.minifyHtmlOutput`           | `true`    | Minify HTML output.                                                                                                                                                                                           |
+| `mjml.mjmlConfigPath`             | ` `       | The path or directory of the .mjmlconfig (or .mjmlconfig.js) file (for custom components use)                                                                                                                 |
+| `mjml.nodemailer`                 | `{}`      | Nodemailer configuration. Please see the [Nodemailer](https://nodemailer.com) documentation for more information.                                                                                             |
+| `mjml.preserveFocus`              | `true`    | Preserve focus of Text Editor after preview open.                                                                                                                                                             |
+| `mjml.previewBackgroundColor`     | `#FFFFFF` | Preview background color.                                                                                                                                                                                     |
+| `mjml.showSaveDialog`             | `false`   | Show the save as dialog instead of input box.                                                                                                                                                                 |
+| `mjml.switchOnSeparateFileChange` | `true`    | Automatically switch previews when editing a different file.                                                                                                                                                  |
+| `mjml.templateGallery`            | `false`   | Show the template gallery instead of quick pick.                                                                                                                                                              |
+| `mjml.templateGalleryAutoClose`   | `true`    | Automatically close template gallery when selecting a template.                                                                                                                                               |
+| `mjml.updateWhenTyping`           | `true`    | Update preview when typing.                                                                                                                                                                                   |
+
+### Include security settings (`mjml.allowIncludes` and `mjml.includePath`)
+
+MJML 5 disables include processing by default for security.
+
+- Set `mjml.allowIncludes` to `true` to enable `<mj-include>` processing.
+- Keep `mjml.allowIncludes` as `false` (default) to ignore all includes.
+- Use `mjml.includePath` to allow includes outside the current template base path.
+
+When includes are enabled:
+
+- Includes in the same folder (or subfolders) as the current MJML file are allowed.
+- Includes outside that folder are denied unless the target folder is listed in `mjml.includePath`.
+
+`mjml.includePath` accepts absolute paths or workspace-relative paths.
+
+Correct JSON example:
+
+```json
+{
+    "mjml.allowIncludes": true,
+    "mjml.includePath": ["resources/templates", "shared/partials"]
+}
+```
+
+Settings UI note:
+
+- In the Settings UI, add each include path as a separate array item.
+- Do **not** paste a full JSON array as one item (for example `"[\"resources/templates\"]"`).
+
+Scope note:
+
+- Workspace settings override User settings.
+- If include behavior is unexpected, check both User and Workspace values for `mjml.allowIncludes` and `mjml.includePath`.
 
 ## Snippets
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "vscode-mjml",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-mjml",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^3.0.4",
         "dotenv": "^17.2.3",
         "mime": "^3.0.0",
-        "mjml": "^5.1.0",
+        "mjml": "^5.2.0",
         "node-mailjet": "^6.0.11",
         "nodemailer": "^7.0.10",
         "prettier": "^3.3.3"
@@ -279,16 +279,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@biomejs/wasm-nodejs": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/@biomejs/wasm-nodejs/-/wasm-nodejs-2.4.13.tgz",
-      "integrity": "sha512-BA64wwPmk5NUz+kP+jrHa8dnIjZSqeX6Q+Q9CC5skZ9c1AqkdS+3vR1QQUzqJ4btbxLPoYVSe1OiTYil7nr8YQ==",
-      "license": "MIT OR Apache-2.0"
-    },
     "node_modules/@colordx/core": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.2.tgz",
-      "integrity": "sha512-oC//VDid7CrDg+iXE/8RBq1s+MP+EFh5ggJOkpM9+ZathjC736A67Yg9LMAQULQ1blj9E0m0g8PubOu1/HniaQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
+      "integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -813,6 +807,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1353,6 +1353,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1496,9 +1505,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1715,9 +1724,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2012,6 +2021,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -2132,12 +2151,12 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.7.tgz",
-      "integrity": "sha512-N5LGn/OlhMxDTvKACwUPMzT34SSj1b022pvUAE/Vh6r2WD1aUCbc+QNIP/JjX9VVxebdJWZQ3352Lt4oF7dQ/g==",
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.9.tgz",
+      "integrity": "sha512-uPR75+5Dk/WJ/YSPR1/YDHdwMM9c5FsaARljfKWgeCKLKOtJ0we21xy/RcCjn53fZnD/f6yYEIZ8pu18+GnbNQ==",
       "license": "MIT",
       "dependencies": {
-        "cssnano-preset-default": "^7.0.15",
+        "cssnano-preset-default": "^7.0.17",
         "lilconfig": "^3.1.3"
       },
       "engines": {
@@ -2148,81 +2167,81 @@
         "url": "https://opencollective.com/cssnano"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.15.tgz",
-      "integrity": "sha512-60kx7lJ40//HA85cIfQXSOJFby2D2V1pOMNHVCxue3KFWCjRzmiQyL9OvI+NAhwUlaojOfF9eK3nGvrJLCBUfQ==",
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.17.tgz",
+      "integrity": "sha512-11qO63A+czwguQFJCaTdICvbaxn0pJzz/XghLlv+OT7WyToDxAMR0Xb3/26/l0y0hQJywwNbj/SLSQlGBHE1OA==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
         "css-declaration-sorter": "^7.2.0",
-        "cssnano-utils": "^5.0.2",
+        "cssnano-utils": "^5.0.3",
         "postcss-calc": "^10.1.1",
-        "postcss-colormin": "^7.0.9",
-        "postcss-convert-values": "^7.0.11",
-        "postcss-discard-comments": "^7.0.7",
-        "postcss-discard-duplicates": "^7.0.3",
-        "postcss-discard-empty": "^7.0.2",
-        "postcss-discard-overridden": "^7.0.2",
-        "postcss-merge-longhand": "^7.0.6",
-        "postcss-merge-rules": "^7.0.10",
-        "postcss-minify-font-values": "^7.0.2",
-        "postcss-minify-gradients": "^7.0.4",
-        "postcss-minify-params": "^7.0.8",
-        "postcss-minify-selectors": "^7.1.0",
-        "postcss-normalize-charset": "^7.0.2",
-        "postcss-normalize-display-values": "^7.0.2",
-        "postcss-normalize-positions": "^7.0.3",
-        "postcss-normalize-repeat-style": "^7.0.3",
-        "postcss-normalize-string": "^7.0.2",
-        "postcss-normalize-timing-functions": "^7.0.2",
-        "postcss-normalize-unicode": "^7.0.8",
-        "postcss-normalize-url": "^7.0.2",
-        "postcss-normalize-whitespace": "^7.0.2",
-        "postcss-ordered-values": "^7.0.3",
-        "postcss-reduce-initial": "^7.0.8",
-        "postcss-reduce-transforms": "^7.0.2",
-        "postcss-svgo": "^7.1.2",
-        "postcss-unique-selectors": "^7.0.6"
+        "postcss-colormin": "^7.0.10",
+        "postcss-convert-values": "^7.0.12",
+        "postcss-discard-comments": "^7.0.8",
+        "postcss-discard-duplicates": "^7.0.4",
+        "postcss-discard-empty": "^7.0.3",
+        "postcss-discard-overridden": "^7.0.3",
+        "postcss-merge-longhand": "^7.0.7",
+        "postcss-merge-rules": "^7.0.11",
+        "postcss-minify-font-values": "^7.0.3",
+        "postcss-minify-gradients": "^7.0.5",
+        "postcss-minify-params": "^7.0.9",
+        "postcss-minify-selectors": "^7.1.2",
+        "postcss-normalize-charset": "^7.0.3",
+        "postcss-normalize-display-values": "^7.0.3",
+        "postcss-normalize-positions": "^7.0.4",
+        "postcss-normalize-repeat-style": "^7.0.4",
+        "postcss-normalize-string": "^7.0.3",
+        "postcss-normalize-timing-functions": "^7.0.3",
+        "postcss-normalize-unicode": "^7.0.9",
+        "postcss-normalize-url": "^7.0.3",
+        "postcss-normalize-whitespace": "^7.0.3",
+        "postcss-ordered-values": "^7.0.4",
+        "postcss-reduce-initial": "^7.0.9",
+        "postcss-reduce-transforms": "^7.0.3",
+        "postcss-svgo": "^7.1.3",
+        "postcss-unique-selectors": "^7.0.7"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/cssnano-preset-lite": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-lite/-/cssnano-preset-lite-4.0.5.tgz",
-      "integrity": "sha512-vTHdb9f9T5WMe7CcoZjlbdtEX27vTgk9nLN5NtLQ5y9lqneZJJgeZ03M1rQRyfO2GtWvOndQUJ8Na6c/4OSBdw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-lite/-/cssnano-preset-lite-4.0.6.tgz",
+      "integrity": "sha512-EI/VDoucl8SmVkXUZtWIux31cWoxgNUbF7njnpPxdz5ZbnKOjAd5DueLuCE1RKKLrOPQsEUaNfUgB1taohIIyQ==",
       "license": "MIT",
       "dependencies": {
-        "cssnano-utils": "^5.0.2",
-        "postcss-discard-comments": "^7.0.7",
-        "postcss-discard-empty": "^7.0.2",
-        "postcss-normalize-whitespace": "^7.0.2"
+        "cssnano-utils": "^5.0.3",
+        "postcss-discard-comments": "^7.0.8",
+        "postcss-discard-empty": "^7.0.3",
+        "postcss-normalize-whitespace": "^7.0.3"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/cssnano-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.2.tgz",
-      "integrity": "sha512-kt41WLK7FLKfePzPi645Y+/NtW/nNM7Su6nlNUfJyRNW3JcuU3JU7+cWJc+JexTeZ8dRBvFufefdG2XpXkIo0A==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.3.tgz",
+      "integrity": "sha512-ynIREMICLxkxm7e9bCR9sh75s4Q5drICi0ua1yxo5jH2XPBqSKkl4dOh4EbFqtUmnTMhRffHgYL0EKKkMjtJTg==",
       "license": "MIT",
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/csso": {
@@ -2465,10 +2484,49 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.352",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3097,9 +3155,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3238,6 +3294,36 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -3753,69 +3839,69 @@
       }
     },
     "node_modules/mjml": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml/-/mjml-5.1.0.tgz",
-      "integrity": "sha512-LYC6BzbpXRT0jJe/dPr3GOzpvIXJQJLTAnYzkLWcdbR7UC5TAx9sZfpZ5DKQi9G00OVhWuuA+pS3L4Fl3Vge2A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml/-/mjml-5.2.0.tgz",
+      "integrity": "sha512-7d3oCSdGnpqcsNT8gKCemXCI1spX3A+XueD986vTB/VgFlda9UmwdflcO9PE2f6BCqri10O4cOCgjq3XhgCcMQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "mjml-cli": "5.1.0",
-        "mjml-core": "5.1.0",
-        "mjml-preset-core": "5.1.0",
-        "mjml-validator": "5.1.0"
+        "mjml-cli": "5.2.0",
+        "mjml-core": "5.2.0",
+        "mjml-preset-core": "5.2.0",
+        "mjml-validator": "5.2.0"
       },
       "bin": {
         "mjml": "bin/mjml"
       }
     },
     "node_modules/mjml-accordion": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-5.1.0.tgz",
-      "integrity": "sha512-BBG+x4ve64N+o2Xc7cRyOhuwC6keZ9olMgQeXXc4GGe7Vj5CKmsnBv9X97/sRIrILxs7jiVw+MrtsHtdzGD0VA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-5.2.0.tgz",
+      "integrity": "sha512-b7ArnxalxJrpeosvVRww3NQUOkicSldpjm/JiGu+Mfw+PaE543tg/pVTfk9yCC96o8jozq2Xxb9FVy4S9iHEjQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-body": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-5.1.0.tgz",
-      "integrity": "sha512-tu8rq+AGjcxiL39Q8pZvt/MTuwLHS+m1E9GVjRVDrL/U1XE7NVvpz1EUeUNo6za0c6pZBIfHd3Zo5JI2QpWzqA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-5.2.0.tgz",
+      "integrity": "sha512-sj6/ohea15bQ9I/M/5lqtg0eZG66gzF9+LIaqI6jFOhb/xy4ZJTGxJ3D9sFFuSrEM1NAT3bZBi+BIs8MJat1mQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-button": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-5.1.0.tgz",
-      "integrity": "sha512-3mclr0auJM4tVREdXTKlU7Ms1Qf4g4amk3yqp5n9DgIfuEUzaE2jn9UZ5xEbZf+7kLoJ2mcgg6lNwGNfkbrJpg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-5.2.0.tgz",
+      "integrity": "sha512-HhQzjVY0ST2CNoZ5jh4/0ZD5vB8H6nNW71RM2IgytZft+GQ6uPveH1r9qN2VJHCvjC8ydVJq4I04hAd+HUgD0Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-carousel": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-5.1.0.tgz",
-      "integrity": "sha512-tLlNkbPQm96BqLrR3s/POOLtaaamXdQaZsbiftpyS8SZsBhJL96tPYp+/jhHY7wI4IbKv9511XH2p6YJHPuT0Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-5.2.0.tgz",
+      "integrity": "sha512-Q892gfU/1L0Qwe5R2KbcDEjAxDbuWLtQS48eVuXBmn0wECegCwCjBH5ZGfjldntwGkK6lZ1byc3Tr3RA+7mFRw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-cli": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-5.1.0.tgz",
-      "integrity": "sha512-PcLKP+90YlxLZ5Smv5AD+y6Gdc4btVMHpapwC6EJDKZgb/4mzb1RwyYtcjci+MLwBb4QxRXJYTIhdCJDViReuA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-5.2.0.tgz",
+      "integrity": "sha512-Sw5oZH1tsyCKjD4ma524Ic7UPoCACVTSg6P/XiEFgKBbqhoNxXLhIfhZwweN8s+8j5EzhOUx7WFAxD1B1Hjtcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -3823,10 +3909,10 @@
         "glob": "^10.5.0",
         "lodash": "^4.17.21",
         "minimatch": "^9.0.3",
-        "mjml-core": "5.1.0",
-        "mjml-parser-xml": "5.1.0",
-        "mjml-preset-core": "5.1.0",
-        "mjml-validator": "5.1.0",
+        "mjml-core": "5.2.0",
+        "mjml-parser-xml": "5.2.0",
+        "mjml-preset-core": "5.2.0",
+        "mjml-validator": "5.2.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3834,184 +3920,183 @@
       }
     },
     "node_modules/mjml-column": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-5.1.0.tgz",
-      "integrity": "sha512-c7O99PcQQPc3Km4N96Uy8mP3CX23s8SE3MD3pp3XFKo8lRdik1RK/5JTS/OOLGL0DxxDdrlVcB/z8ttvvtiVDg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-5.2.0.tgz",
+      "integrity": "sha512-higZK6DNd6xqcCrnRK64Yxj5aDtj936BXtmFFVGae51PZNCAhWyI6uCmOi4riSU1sTk/eM/IrNyao4bSMOsQFw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-5.1.0.tgz",
-      "integrity": "sha512-vEWGomEZFMR6sXmnJiWeC1p/IRo2KnJm/YSwKsTQCp+bXvvDg+Uq0Xtcsrg9ugGCnTheMlngwE+SVJieE7d5nQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-5.2.0.tgz",
+      "integrity": "sha512-gJYgprY+wD0g5WkbrZOxn6bxLmYFH8WM4ZuHZIWGHIt2dogff1u5FiirL+ezWskOp1CdNEavuLRK5bYiSuw8LQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "@biomejs/wasm-nodejs": "^2.4.12",
         "cheerio": "1.0.0",
         "cssnano": "^7.1.2",
         "cssnano-preset-lite": "^4.0.4",
         "detect-node": "^2.0.4",
         "htmlnano": "^3.2.0",
+        "js-beautify": "^1.15.4",
         "juice": "^11.0.0",
         "lodash": "^4.17.21",
-        "mjml-parser-xml": "5.1.0",
-        "mjml-validator": "5.1.0",
-        "postcss": "^8.5.8",
-        "prettier": "^3.8.1"
+        "mjml-parser-xml": "5.2.0",
+        "mjml-validator": "5.2.0",
+        "postcss": "^8.5.8"
       }
     },
     "node_modules/mjml-divider": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-5.1.0.tgz",
-      "integrity": "sha512-88eWT0fFWjbmKBJth2v/vuS2ZM28ySiPDSl5nOBVhUdgCBKn1XctjYP5EO/vCOmp574jXJ4gSwccDIcuaYE1yg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-5.2.0.tgz",
+      "integrity": "sha512-JETEfM8pjftaYmOCTLBsRYNYG1muv0SW4T+xmtmtT7DHqWmx/bku/G50BHATXX1cFCnl9wIJHDtLVRSv6nNiaQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-group": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-5.1.0.tgz",
-      "integrity": "sha512-L/Q8bl00VbGMR05YfNz6adru1jfxeUILfIgQPlc3aZpY+jztbCv3LANVd96uKxDIixBPdr6nY0q5iUjNeHcDEQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-5.2.0.tgz",
+      "integrity": "sha512-DfR8lTPxTqyRWYoSLbhUKQR1SL1q8WF/Y9PB1V4uZJ23Gg4HJDvjWhsYX5K+LC91dWq4ZfRrDZNJWm1e+sIPew==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-head": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-5.1.0.tgz",
-      "integrity": "sha512-KhVG6TNG22ih88Ppax7f4nUq6v/r8Ez95x9Y/eWb17d+ixZiPYU4mHU3oSZ9hwI6IiOA4zdXNdPJlejpY8NWww==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-5.2.0.tgz",
+      "integrity": "sha512-h5/uJ0CFNXei5izYC+5iepDo/mc+57fM7LlDOELb1VAgoesvNewAwH44hkCAqFTPIUJrilJ11VcxLy+sQuIs6Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-head-attributes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-5.1.0.tgz",
-      "integrity": "sha512-ER/tLu/ukWgpEre7O05LSpznkNboRNfUfelzrc/XYnANeB06Z3J64NlrDIIQPAlHK1hj/kJ0kgSowlxmw4w/ZQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-5.2.0.tgz",
+      "integrity": "sha512-n0vnuTfNSTpyn2zRRz8mfS3O78voARhKRf5/1vKF1RHNiZDNNNIAOx/VyCW0gsDGCRQzVlzOcQq8Rg+CLniLdw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-head-breakpoint": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-5.1.0.tgz",
-      "integrity": "sha512-/dWgmc9NcrpJnK4HhzyZP/2+oh8q+JvRJP10vu+wrHi0o1P/iDS1HRbSAl+aKZwXRvsimcQVlKtNzX/x45tw4g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-5.2.0.tgz",
+      "integrity": "sha512-B0aOgpxHXPFnHBIoz1WMtXDCZ8qyQCiTo/t1V/Evps9ame0XeTXkDasOiUmGX1mIURc6M43M4HWVgqWPtu/RGA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-head-font": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-5.1.0.tgz",
-      "integrity": "sha512-73GmQrt8NyKE9tXaUJ/3UMRFFaclUSDLbBG+bKkU4/x4V1cwjLLnMDAGufvhTFnRPvZCPyEBUdbPtpe7is9bRQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-5.2.0.tgz",
+      "integrity": "sha512-JW6TAgYVwEqf2erxZOwKhLV5iKWq8E9lg6zLs66E2IZsej0VIKbsKy8P0NMg7SZUfIFOJ1oRbA0lqc3dJBbwbw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-head-html-attributes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-5.1.0.tgz",
-      "integrity": "sha512-/XP7stL4KJeVFvfu4u74ZcTuY/ceZppyoHB81uEjyt5NWR/xmZ0nDGedNZctkwov5OdEMahwdvcB3HuZsIPKdw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-5.2.0.tgz",
+      "integrity": "sha512-GjizDLevp8bSl4IPvKeXeo9UoZQ5lVLefSn2LaQ5b6EKcwbzk/+1RE+sa7AwPtJnfcIaWi29+b37Hb1ioC1rmQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-head-preview": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-5.1.0.tgz",
-      "integrity": "sha512-pymuqtu6bAAa7+WO4y0hI3AkwibFRk3MRVZpoLZbGvFOCG6eQEOa7do+eoAM6VAJDdJHmuTygQqJjnFJxLruFA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-5.2.0.tgz",
+      "integrity": "sha512-6nKJu3HI3aPBOPDyZW7dxmgxLy55YESmBTTdlcNZ6rtvIgsQCHdlGn2vCW6lMVTFZ2M4PT5AekMBsKxQn6L/Rg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-head-style": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-5.1.0.tgz",
-      "integrity": "sha512-IBTO3H7dj8gqWat5DQrgPE5vX+IRbPtuTkt1LySQ1uVkhc3drUdKeHSkOdvd+a+bdYRnknR46lKHYSBbEhPNKw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-5.2.0.tgz",
+      "integrity": "sha512-sVIn+LdHy8W6FYgjYlc5R1hqUTVxmTp1DechUApD9DKFgWrg1edl2s5b8tNnJucoz3y1g6i+pjacKmqcc9ZG1g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-head-title": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-5.1.0.tgz",
-      "integrity": "sha512-M0+QEyPCCeeee2+MvuUleHNE4Hhc0Qm+WU17wj+3J5ZP7PvSnD74ithvOd3JVeuiTp/OZWfAFq9xkhMmDs9a4A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-5.2.0.tgz",
+      "integrity": "sha512-iFjJRhUY6D5QZN9Y8IZXQUl1I8PYNdzF6PzEvtQ3ZFcSVYLWDRUK7KJNIIlDZcv5qmd1wbnh2Nan8+HPumcrsA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-hero": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-5.1.0.tgz",
-      "integrity": "sha512-MmNtjDWzyKxq0pDjNO59eOcnxP1l4+IV4YrpGSYoXe6CoekJSvl73Wf5Jtl1jXmAfOoNREf9+YWp1uvIeadkQQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-5.2.0.tgz",
+      "integrity": "sha512-LB7ptmY/oj74UkJHJEeayEkk3bS9CI4UMDNUk4VfepuJBuBWGPTkfGifUz5YAuCSy5pSreZ9tPup5JQBc5drHg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-image": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-5.1.0.tgz",
-      "integrity": "sha512-Mw84CZQA0cOq7SYKGEgLpujWt5y6mM7sEFJUp1IDFITUe448NYWHfvP2o1PGouhsQf8WQ+C7fx07h0qNAA8fsA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-5.2.0.tgz",
+      "integrity": "sha512-WtJa2U37kn2gMyfmUfLh4l805oiMlDXCxBjSRdRBNfX17lhdWKjaXYwg4Dfy9kepkxGN471bhTbIKgF7pmmL0Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-navbar": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-5.1.0.tgz",
-      "integrity": "sha512-N/nATgUSGWNHOlZlbfD100sYKJfDpcQdEgvYA2sfP5jU+9CQzIpoSyF6VsfRt40YOp51gOZCr0WzXH3f7QBFvA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-5.2.0.tgz",
+      "integrity": "sha512-IE8xVcLR9bhQR2Nt0zWoQvi8mbKsTJUICtC2o2ytw7eYEulOSNSOpp/PrB/UteKrAziVE6Ny3HnYuA/lN1LlSQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-parser-xml": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-5.1.0.tgz",
-      "integrity": "sha512-mskmyGgTLJi7o/FK/l49FRrkxfIb+T5HGLXAEzFWTyEC9tZlYNV4OM1S1U/6rQkzV+ePYGYQ+xEodKEod93nSg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-5.2.0.tgz",
+      "integrity": "sha512-2aXPhR1yMZbJ+6rIQxAlTTmxZdSkfZjfFIgtl6/yAFguuUjSskwxXz6aNLajcYMHhRghGr+VNeMKqJ9SMc+lKQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -4021,124 +4106,124 @@
       }
     },
     "node_modules/mjml-preset-core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-5.1.0.tgz",
-      "integrity": "sha512-1fzAGIoCdz3R9qhz7E7u3Fq0V/hC+trjphl0dCZluOsjTw9G293xP25u6aQAEYc4QooDek/hLRRkV6oPCxRXXw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-5.2.0.tgz",
+      "integrity": "sha512-A7dO+mWi2I4r+VRGrzJ/O9P2y450wdBp22gacjDEUtoN0uORvviFxKQYgCKeZmq+i+fNvGjgtoclj2x+pQ/3EQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "mjml-accordion": "5.1.0",
-        "mjml-body": "5.1.0",
-        "mjml-button": "5.1.0",
-        "mjml-carousel": "5.1.0",
-        "mjml-column": "5.1.0",
-        "mjml-divider": "5.1.0",
-        "mjml-group": "5.1.0",
-        "mjml-head": "5.1.0",
-        "mjml-head-attributes": "5.1.0",
-        "mjml-head-breakpoint": "5.1.0",
-        "mjml-head-font": "5.1.0",
-        "mjml-head-html-attributes": "5.1.0",
-        "mjml-head-preview": "5.1.0",
-        "mjml-head-style": "5.1.0",
-        "mjml-head-title": "5.1.0",
-        "mjml-hero": "5.1.0",
-        "mjml-image": "5.1.0",
-        "mjml-navbar": "5.1.0",
-        "mjml-raw": "5.1.0",
-        "mjml-section": "5.1.0",
-        "mjml-social": "5.1.0",
-        "mjml-spacer": "5.1.0",
-        "mjml-table": "5.1.0",
-        "mjml-text": "5.1.0",
-        "mjml-wrapper": "5.1.0"
+        "mjml-accordion": "5.2.0",
+        "mjml-body": "5.2.0",
+        "mjml-button": "5.2.0",
+        "mjml-carousel": "5.2.0",
+        "mjml-column": "5.2.0",
+        "mjml-divider": "5.2.0",
+        "mjml-group": "5.2.0",
+        "mjml-head": "5.2.0",
+        "mjml-head-attributes": "5.2.0",
+        "mjml-head-breakpoint": "5.2.0",
+        "mjml-head-font": "5.2.0",
+        "mjml-head-html-attributes": "5.2.0",
+        "mjml-head-preview": "5.2.0",
+        "mjml-head-style": "5.2.0",
+        "mjml-head-title": "5.2.0",
+        "mjml-hero": "5.2.0",
+        "mjml-image": "5.2.0",
+        "mjml-navbar": "5.2.0",
+        "mjml-raw": "5.2.0",
+        "mjml-section": "5.2.0",
+        "mjml-social": "5.2.0",
+        "mjml-spacer": "5.2.0",
+        "mjml-table": "5.2.0",
+        "mjml-text": "5.2.0",
+        "mjml-wrapper": "5.2.0"
       }
     },
     "node_modules/mjml-raw": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-5.1.0.tgz",
-      "integrity": "sha512-Pn5qpWAfhIH7fMWwuAzvq0gVXAaTafNR68Aky+tsIZX5bPS4e/bXSc0ym0LttHGEDQDU+uGBuxld0zo+03/l0w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-5.2.0.tgz",
+      "integrity": "sha512-ubCV/RUj0MyMzaXSk/axp3fziLBmvuqWleepS/dUytn33kLN23zSIQpJlcpOAG/scsMYG8y74oARcSIPFN3sJQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-section": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-5.1.0.tgz",
-      "integrity": "sha512-fNXKy9vgR/PeeLegJPLPo6wANYBHNfYfhhZO4FJ40cl21qI44LFyZV05/g5SQoFyZQbcfPjpYYevos1WQx2o1w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-5.2.0.tgz",
+      "integrity": "sha512-0vqblM90JDBg8ZHiOS5c2nxYM6VjnZHdCRaC3dylzbbKThQOnCNWrF5WXWoaRh7jK+dj9kqssG7BkVSkN9s2lw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-social": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-5.1.0.tgz",
-      "integrity": "sha512-i5BckFxIfu1YPMTxPy18EBF80Gti9sPUg318XvfyJEUDl9KCffMfrGEysa3MGrbKwGliGkbeZn3CG2Ds/U3XGg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-5.2.0.tgz",
+      "integrity": "sha512-YKNg8A0KN8y+kbA76BBQH5r1Z5jOLLyy+WxtgyBoMbGhRacoG/P7ogxEgEgTBGO1ieAlFODgOzWJF1usjTU6Ig==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-spacer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-5.1.0.tgz",
-      "integrity": "sha512-aihrzkAxwIuINU1nT41EVOX+b5ojdB394WcYXOtc+y6km8aZ8wnJg94iatq3b8oAXbAgNZ9bVFne0oCHGD/7Rw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-5.2.0.tgz",
+      "integrity": "sha512-2zXD/6mhGkeW5sOzVYy6lsM0n+lkqToXNxxSIvlopNExLU1Xlc1f6h772Lsli+fNGVBLIPfTWAViMXdwFFttxg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-table": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-5.1.0.tgz",
-      "integrity": "sha512-a43di9RlOU7lDPRlPAPdLowQqLBZI1kGRMrjnVxb8i4Gy+Jt+RfhfBenSNE4IZq5OnopYRL8PAVSRL3N+ANuhw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-5.2.0.tgz",
+      "integrity": "sha512-xEmS4R0tX4IfxN4Uaez35aQHZ+cMVlxPa1n5rtl/hRTCrNCCs4PKcCw6wWbTyfFvykZ4PoYvGV3r9+480D3a+A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-text": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-5.1.0.tgz",
-      "integrity": "sha512-0ue9ubdN2bgXhLmcwpbLL8fX1FSwvguX5XFMP87B6g+TXfCXhOWh3g+MD9RnoKw4xpx9gvMC8h8R5a5LfHY5Zg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-5.2.0.tgz",
+      "integrity": "sha512-jpPv+Yt3YiY/OvYxEOudR5dIlxm5xvopjyW6iObng4cQtVGrSEtqc8Wg7Fzq96+PKcFpsL8X+GCUFqCYuNuOfg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0"
+        "mjml-core": "5.2.0"
       }
     },
     "node_modules/mjml-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-5.1.0.tgz",
-      "integrity": "sha512-FTyyEELy9ulKLhkPWit6wzuO3e5NcGImQah6XY/0QHTDHnunuNpYjaGW7NcoWwmuoAjIpScZUZ1sUv1pH6FNJQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-5.2.0.tgz",
+      "integrity": "sha512-vj5kaJ6FIvcGAecM84RcfogSWrQoB8IciuDpg5+v4K2E3OURr2yJ022Z30n+9eyuu2QhZHsR68d9Ip0aR/Tt2Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       }
     },
     "node_modules/mjml-wrapper": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-5.1.0.tgz",
-      "integrity": "sha512-rOTGyTmC+lUcnFIyKnR8l6uPCNAs+E3hYwZ6y8t1GYfcuJhEZFmCCHqyoaZhvcH56Gg1TXSvDJlyZjOk8FHeZA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-5.2.0.tgz",
+      "integrity": "sha512-GIoaxkvgO41l+FxYOg1W/KMDPAFdhLKVTE3eF83nMW8r+wp3zaga23E/IoRCUHRmNisUEnC677oJQgjTslng8g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.1.0",
-        "mjml-section": "5.1.0"
+        "mjml-core": "5.2.0",
+        "mjml-section": "5.2.0"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -4164,9 +4249,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -4253,6 +4338,21 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/normalize-path": {
@@ -4537,9 +4637,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4581,12 +4681,12 @@
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.9.tgz",
-      "integrity": "sha512-EZpoUlmbXQUpe+g4ZaGM2kjGlHrQ7Bjzb3xHcNrC9ysI1tGoib6DAYvxg6aB7MGxsjgLF+Qx/jwZQkJ5cKDvXA==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.10.tgz",
+      "integrity": "sha512-yFr6JezOolHLta/buLE71VKPh2mXursp4saVe98/ol8ZnEWhL+racShqPKlvd/DKWLre/39B6HhcMXf7RZ3hxg==",
       "license": "MIT",
       "dependencies": {
-        "@colordx/core": "^5.2.0",
+        "@colordx/core": "^5.4.3",
         "browserslist": "^4.28.2",
         "caniuse-api": "^3.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -4595,13 +4695,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.11.tgz",
-      "integrity": "sha512-H+s7P0f9jJylSysAHs3/5MhAx7GthDO05uw1h56L2xyEqpiLTFLEqBNw3PUYzD5p/AKwWaigCXf6FGELpOw9lw==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.12.tgz",
+      "integrity": "sha512-xurKu5qqk4viR3Cp3p4xBR4KfnZm4w4ys6+UBwBmeuBSNkH7+DtLnYOYnOffgtE4yx8sH9S1VZ6RAAvROXzP2Q==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
@@ -4611,13 +4711,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.7.tgz",
-      "integrity": "sha512-FJhE3fSte7HaRNL4iwD8LTG9vWqj3puxXIdig6LfrFqc1TJRUhY4kXOkeTXZZfTXYny+k+SO7fd2fymj1wduJg==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.8.tgz",
+      "integrity": "sha512-CvvS5S9WrXblFXCEJ9nVo+4z+eA7zSC7Z88V1HEJuwlQhlFnYTIjg1xJY+BCUiG2bvICap2tXii4mP22BD108Q==",
       "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^7.1.1"
@@ -4626,83 +4726,83 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-discard-duplicates": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.3.tgz",
-      "integrity": "sha512-9cRxXwhEM/aNZon1qZyToX4NmjbFbxOGbww+0CnbYFDbbPRGZ8jg4IbM8UlA+CzkXxM35itxyaHKNqBBg/RTDg==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.4.tgz",
+      "integrity": "sha512-VBNn1+EuMZkeGVVtz0gRfbNGtx9IFgAsAV+E2pHtXPrp4qfGBkhTIiAuE/wrb+Y6Pakg9NewAlfTpYIFAWODtw==",
       "license": "MIT",
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-discard-empty": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.2.tgz",
-      "integrity": "sha512-NZFouOmOwtngJVgkNeI1LtkzFdYqIurxgy4wq3qNvIiXFURTZ3b/K7q3dP3QitlWQ5imHDQL0qSorItQhoxb1g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.3.tgz",
+      "integrity": "sha512-M2pyjQCU+/7cMHVtL6bKTHjv0lZnPLMpicgr67Dlth7AbuV9gjVTtUqaRwn6Pp6BwSDspUzhz8SaUrRykJU5Dw==",
       "license": "MIT",
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-discard-overridden": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.2.tgz",
-      "integrity": "sha512-Ym01X4v6U3sY8X0P1J9P+RTar+7JyLTOzDrxKSeaArFsLmkVu4KcAKPBWDYRIyZ/q4jwpSPnOnekeSSqXSXKUw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.3.tgz",
+      "integrity": "sha512-aNovXo9UsZuRNLzHJtp13lHIvinDPfiXBPePpXkSjCbgp++iU2FqE+YxvjIsg6EdyPZsASFbfu+JcBFVsErXIQ==",
       "license": "MIT",
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.6.tgz",
-      "integrity": "sha512-lDsWeKRsssX/9vKFpingoRiuvGajtOGCJhs1kyaTJ5fzaVzs0aPPYe38UZ/ukMFEA5iuRIjQJHIkH2niYO3ubQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.7.tgz",
+      "integrity": "sha512-b3mfYUxR388u5Pt0HPcVIUtUDn/k15UfTY9M+ORW+meCR6JLNxoZffiYvXyOYQoRYQNZyX/UFkMCM/mNHxe1qA==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^7.0.10"
+        "stylehacks": "^7.0.11"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.10.tgz",
-      "integrity": "sha512-UXYKxkg8Cy1so/evF7AE/25PNXZb3E0SrvjdbtbGf+MW+doLenKqRLQzz6YZW469ktiXK2MVLFWtel/DftCV0Q==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.11.tgz",
+      "integrity": "sha512-SJUPM18g2BmPhf8BVlbwqWz4aK3pLu6u6xjfwEzra7xL6IBR10sUaiB++EzqcVfadPHrKBSMlNdP+XieykhI+Q==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
         "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^5.0.2",
+        "cssnano-utils": "^5.0.3",
         "postcss-selector-parser": "^7.1.1"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-minify-font-values": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.2.tgz",
-      "integrity": "sha512-Z82NUmnvhPrvMUaHfkaAVBmWQq9F8Dox4Dy0LiwbaTxfmDUWLQtS+0WCgKViwdWCPPajiY9YzoQftgqKdXkM5g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.3.tgz",
+      "integrity": "sha512-yilG/VOaNI74IylQvAQQxm3/wZVBkXyYUqNUAdxqwtbWUXPsbK1q8Ms0mL83v+f8YicgcyfYCRZtWACUdYajpA==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4711,47 +4811,47 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-minify-gradients": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.4.tgz",
-      "integrity": "sha512-g8MNeNyN+lbwKy8DCtJ6zU6awBL0InBsSOaKmgZ1MdRLVItLQUNFNAzzzBnOp4qowOcyyB6GetTlQ0/0UNXvag==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.5.tgz",
+      "integrity": "sha512-YraROyQRg3BI1+Hg8E05B/JPdnTm8EDSVu4P2BxdM+CRiOyfmou809+chGIqo6fQqwjPGQ947nbGncSjmTU1WQ==",
       "license": "MIT",
       "dependencies": {
-        "@colordx/core": "^5.2.0",
-        "cssnano-utils": "^5.0.2",
+        "@colordx/core": "^5.4.3",
+        "cssnano-utils": "^5.0.3",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.8.tgz",
-      "integrity": "sha512-DIUKM5DZGTmxN7KFKT+rxt0FdPDmRrdK/k3n3+6Po+N/QYn06juwagHcfOVBG0CfCHwcnI612GAUCZc3eT+ZEg==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.9.tgz",
+      "integrity": "sha512-R8itbB8BhlpoYyBm1ou0dD+vJnQ3F6adQipR4UnkCHUwlo+S9WXJaDRg1RHjC8YVAtIdrQzSWvJl40HnGDTKjA==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
-        "cssnano-utils": "^5.0.2",
+        "cssnano-utils": "^5.0.3",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.1.0.tgz",
-      "integrity": "sha512-HYl/6I0aL+UvpA10t65BSa7h+tVjBgE6oRI5N/3ylX3vtwvlDL67G3FT3vYDPnTksxr0riiyJcT0tBtyRVoloA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.1.2.tgz",
+      "integrity": "sha512-aQtrEWKwqafNlExcKHQvPGsXR2+vlUqqJtf5XsCQcgsSb5PL4wlujWBYDJuWsP4UnQX1YHDHU8qRlD+1PzTQ+Q==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.1",
@@ -4763,25 +4863,25 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-charset": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.2.tgz",
-      "integrity": "sha512-YoINoiR4YKlzfB95Y93b0DSxWy7FLw+1SADIaznMHb88AKizpzfF80tolmiDEbYr1UM4r4Hw+NZq37SwT5f3uw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.3.tgz",
+      "integrity": "sha512-NoBfZu8PR4c2NlmjvrqQTzCzLY79hwcSRgNQ3ZiNK0ABzf9kYKloE/jNj+/8GQY1wsm8pRRgANk6ydLH8cwo0Q==",
       "license": "MIT",
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-display-values": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.2.tgz",
-      "integrity": "sha512-wu/NTSjnp8sX5TnEHVPN+eScjAtRs18ELtEduG+Ek3GxjeUDUT+VAA3PJjVIXBcVIk6fiLYFj2iKH0q99S3T2Q==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.3.tgz",
+      "integrity": "sha512-ldsCX0QIt05pKIOobZtVQ48wXJecr+czw4+e1/YjVhLMqslShgpVxgPtI2CefURR8oyVoYaU/l829MMwExDMLw==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4790,13 +4890,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-positions": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.3.tgz",
-      "integrity": "sha512-1CJI++oA3yK/fQlPUcEngUfcSWS08Pkt9fK+jVgL53mmtHDBHi0YiuB0m3D9BXwZjmfvCc2GQmFqCAF/CVcPzQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.4.tgz",
+      "integrity": "sha512-VEvlpeGd3Ju1Hqa/oN4jaP3+ms4laYwkEL9N9u+B6k54PZjXbW1n6wI+aVprf1BQXlCYpS5+1pl/7/vHiKgARg==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4805,13 +4905,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.3.tgz",
-      "integrity": "sha512-RvImJ2Ml4LZSx31qC2C8LDiz65IgBNATtwEr9r3Aue+D0cCGbj4rjNojb/uGpEm4QxnOTzFqMvaDYuKiT1Cmpg==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.4.tgz",
+      "integrity": "sha512-6mPKlY/8cSaDHxX502wERADarJsccwlky6yIrOapHH2ZgfoKAV94SbiTKfKEs4EEpdazuc3J72WsqeYk7hp9+Q==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4820,13 +4920,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-string": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.2.tgz",
-      "integrity": "sha512-FqtrUh2BU2MnVeLeWBbJ2rwOjuDnA91XvoImc1BbgMWIxdxiPTaquflBHsmFBA3xh3pC3wPZO9W5MaIc7wU/Xw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.3.tgz",
+      "integrity": "sha512-HnEQPUchi1eznmDKEYrKUTqrprEq97SrpUYClgUkv7V2zRODD9DFoUsYU+m9ZOetmD5ku7fEMZB/lwy8IT6xVQ==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4835,13 +4935,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.2.tgz",
-      "integrity": "sha512-5H5fpXBnMACEXzn7k9RP7qWZ1eWg8cuZkUuFygStY7icOj+UucwMWXeMmdkF/iITvTVa7fP85tdRCJeznpdFfQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.3.tgz",
+      "integrity": "sha512-zmEzHdvpZBZu0OKlbJSfgASQvaayyAoVuWtvyr34IJ/LyS+DaOKvvR3EvFJ9RWWtNIx+CMvO125OVophaxNYew==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4850,13 +4950,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.8.tgz",
-      "integrity": "sha512-imCM3cwK3hvlAG4z1AzYM24m8BPA3/Jk/S71wfbn2I6+E2b+UwFaGvlNqydihXTSl3OFPeQXztqCzg+NGeSibQ==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.9.tgz",
+      "integrity": "sha512-DRAdWfeh/TjmhLJsw91vdiWCnUod9iwvM7xyS02/nF/sLsCR3A8l3pztrSUrWG8DSBqfX7yEk9FM0USaVJ2mSg==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
@@ -4866,13 +4966,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-url": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.2.tgz",
-      "integrity": "sha512-bLnNY7t76NLRb9QQyCVmCN4qwoHxiq6vABH/CXav9wTuR6dNGHGQ72AyO/+h2quWxZk3l7BqxNL1vtDi9H6y1g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.3.tgz",
+      "integrity": "sha512-CL93wmloq5qsffmFv+bw24MIRbmhHrp53qoh1LDAb/5TtjWEXI/np4xcP/Gw9oWCb2XyWnqHYLDUwiKRoJBA1Q==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4881,13 +4981,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-normalize-whitespace": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.2.tgz",
-      "integrity": "sha512-TNSVkuhkeOhl36WruQlflxOb7HweoeZowSusNpfsM1+ZvqJ24Mc+xksu05ecMQxlu+0zgI8pyznO2EWqDCQbLA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.3.tgz",
+      "integrity": "sha512-FdHjjn+Ht5Z2ZRjNOmeCbNq6lq09sUYKpmlF/Aq0XjVNSLTL6fmHlA/3swN2wP2caY9GV/tjSDcIIyS7aN7W0A==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4896,29 +4996,29 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-ordered-values": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.3.tgz",
-      "integrity": "sha512-FTt6R9RF7NAYfpOHa2XFPm89FVuo5GiIbcfwOXFy1MYF38BeiNW9ke8ybw9Pk62eEsUlRVVbxHWA3B7ERYqOOA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.4.tgz",
+      "integrity": "sha512-nubSi49hDHQk4E8KIj+IbLY8Bg+8OcSUEhgyolgM+atnOvXjV7EjaR6bac4YGZoFyPa9mWoAF3EaYbWdFkKqVg==",
       "license": "MIT",
       "dependencies": {
-        "cssnano-utils": "^5.0.2",
+        "cssnano-utils": "^5.0.3",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.8.tgz",
-      "integrity": "sha512-VeVRmbgpgTZuRcDQdqnsB4iYTeS2dBRV07UdwK6V3x61F1xTQ2pgIzHBIR4rQYRlXRNKBTGYYhEL1eNA7w9vaQ==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.9.tgz",
+      "integrity": "sha512-ztTNPdIxXTxtBcG03E9u8v44M4ElXbMIRT7pf2onlquGula0Y83nKKxqM22FA/hMgkfCjN7ohevkVlaNwI8iOQ==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
@@ -4928,13 +5028,13 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-reduce-transforms": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.2.tgz",
-      "integrity": "sha512-OV5P9hMnf7kEkeXVXyS5ESqxbIls7a3TqFymUAV5JICO/9YCBEU+QQhQjZiDHaLwFdV7/CL481kVeBUk5FdY3w==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.3.tgz",
+      "integrity": "sha512-FXsnN9ZwcZTT8Yf8cAHA8qIGUXcX6WfLd9JoYhrdDfmvsVhhfqkkv7m4AC3rwFOfz+GzkUa87OCKF9dUcicd+g==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -4943,7 +5043,7 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -4960,9 +5060,9 @@
       }
     },
     "node_modules/postcss-svgo": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.2.tgz",
-      "integrity": "sha512-ixExc8m+/68yuSYQzV/1DgtTup/7nI2dN9eiDS5GMRUzeCH4q9UcqeZPwcSVhdf8ay9fRwXDUHwcY5/XzQSszQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.3.tgz",
+      "integrity": "sha512-2QfoFOYMcj8lwcVEf9WeTlkVIAm7u2QvOEhMzkQU3KUhhGX/l8hVV9EtjMv4iq3E9iI3OeeMN0YoMLbGusuigw==",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
@@ -4972,13 +5072,13 @@
         "node": "^18.12.0 || ^20.9.0 || >= 18"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-unique-selectors": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.6.tgz",
-      "integrity": "sha512-cDxnYw1QuBMW5w3svZ0BlYF0IA4Amr+1JoTLXzu6vDFPNwohN2QU+sPZNx15b930LR7ce+/600h28/cYoxO9vw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.7.tgz",
+      "integrity": "sha512-d+sCkaRnSefghOUdH8CMJZV9yUQhj2ojpe8Nw/lA+LV1UOfeleGkLTl6XdCFFSai9UJ+DJPb69FFuqthXYsY8w==",
       "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^7.1.1"
@@ -4987,7 +5087,7 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -5165,6 +5265,12 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -5628,9 +5734,9 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.10.tgz",
-      "integrity": "sha512-sRJ7klmhe/Fl5woJcbJUa2qP1Ueffsl1CQI4ePvqXLkZmcIuAt09aP9uT/FOFPqXh9Rh8M5UkgEnwTdTKn/Aag==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.11.tgz",
+      "integrity": "sha512-iODNfhXVLqc5LADs+Y6Oh5wJuK5ZcHbVng8aiK3y9pjMQdc5hLrBW0eFU6FtnpNrE6PoEg/MmFTU4waotj5WNg==",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
@@ -5640,7 +5746,7 @@
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
       "peerDependencies": {
-        "postcss": "^8.5.10"
+        "postcss": "^8.5.13"
       }
     },
     "node_modules/supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-mjml",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-mjml",
-      "version": "2.3.1",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-mjml",
   "displayName": "MJML Official",
   "description": "MJML preview, lint, compile for Visual Studio Code.",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "publisher": "mjmlio",
   "license": "MIT",
   "readme": "README.md",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-mjml",
   "displayName": "MJML Official",
   "description": "MJML preview, lint, compile for Visual Studio Code.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "publisher": "mjmlio",
   "license": "MIT",
   "readme": "README.md",
@@ -167,6 +167,19 @@
           "description": "The path or directory of the .mjmlconfig (or .mjmlconfig.js) file (for custom components use)",
           "type": "string"
         },
+        "mjml.allowIncludes": {
+          "default": false,
+          "description": "Enable mj-include processing. Disabled by default for security.",
+          "type": "boolean"
+        },
+        "mjml.includePath": {
+          "default": [],
+          "description": "Additional directories to allow for <mj-include> lookups. Supports absolute paths, or paths relative to the workspace root.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "mjml.keepComments": {
           "type": "boolean",
           "default": true,
@@ -301,7 +314,7 @@
     "@types/mime": "^3.0.4",
     "dotenv": "^17.2.3",
     "mime": "^3.0.0",
-    "mjml": "^5.1.0",
+    "mjml": "^5.2.0",
     "node-mailjet": "^6.0.11",
     "nodemailer": "^7.0.10",
     "prettier": "^3.3.3"

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, statSync } from 'fs'
 import { basename, dirname, join as joinPath, parse as parsePath, isAbsolute } from 'path'
-import { TextDocument, TextEditor, window, workspace } from 'vscode'
+import { TextDocument, TextEditor, Uri, window, workspace } from 'vscode'
 
 import mime from 'mime'
 
@@ -27,11 +27,14 @@ export async function mjmlToHtml(
     }
 
     const keepComments = workspace.getConfiguration('mjml').get<boolean>('keepComments', true)
+    const allowIncludes = workspace.getConfiguration('mjml').get<boolean>('allowIncludes', false)
+    const includePath = getIncludePath(path)
 
     return await mjml2html(mjmlContent, {
       beautify,
       filePath: path,
-      ignoreIncludes: false,
+      includePath: allowIncludes ? includePath : undefined,
+      ignoreIncludes: !allowIncludes,
       keepComments,
       minify,
       mjmlConfigPath: mjmlConfigPath
@@ -64,11 +67,60 @@ export function getPath(): string {
 }
 
 function getCWD(mjmlPath?: string): string {
-  if (workspace.rootPath) {
-    return workspace.rootPath
+  if (mjmlPath) {
+    const workspaceFolder = workspace.getWorkspaceFolder(Uri.file(mjmlPath))
+    if (workspaceFolder) {
+      return workspaceFolder.uri.fsPath
+    }
+  }
+
+  if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+    return workspace.workspaceFolders[0].uri.fsPath
   }
 
   return mjmlPath ? parsePath(mjmlPath).dir : ''
+}
+
+function getIncludePath(mjmlPath?: string): string[] | undefined {
+  const config = workspace.getConfiguration('mjml').get<string | string[]>('includePath', [])
+  const includePath = normalizeIncludePathConfig(config)
+  const basePath = getCWD(mjmlPath)
+
+  const normalized = includePath
+    .map((value: string) => value.trim())
+    .filter((value: string) => value.length > 0)
+    .map((value: string) => (isAbsolute(value) ? value : joinPath(basePath, value)))
+
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function normalizeIncludePathConfig(config: string | string[]): string[] {
+  const rawValues = Array.isArray(config) ? config : [config]
+  const expanded = rawValues.flatMap((value: string) => {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return []
+    }
+
+    if (trimmed.startsWith('[') || trimmed.startsWith('{') || trimmed.startsWith('"')) {
+      try {
+        const parsed = JSON.parse(trimmed)
+        if (Array.isArray(parsed)) {
+          return parsed.map((entry: any) => String(entry))
+        }
+
+        if (typeof parsed === 'string') {
+          return [parsed]
+        }
+      } catch {
+        // Keep raw value if it's not valid JSON.
+      }
+    }
+
+    return [trimmed]
+  })
+
+  return expanded
 }
 
 function encodeImage(filePath: string, original: string): string {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from 'fs'
-import { basename, dirname, join as joinPath, parse as parsePath, isAbsolute } from 'path'
+import { basename, dirname, join as joinPath, parse as parsePath, isAbsolute, relative } from 'path'
 import { TextDocument, TextEditor, Uri, window, workspace } from 'vscode'
 
 import mime from 'mime'
@@ -144,6 +144,66 @@ function encodeImage(filePath: string, original: string): string {
   return original
 }
 
+export function warnAboutIncludes(mjmlContent: string, mjmlPath?: string): void {
+  const includeRegex = /<mj-include\s+[^>]*path=["']([^"']+)["']/g
+  const includes: string[] = []
+  let match: RegExpExecArray | null
+
+  while ((match = includeRegex.exec(mjmlContent)) !== null) {
+    includes.push(match[1])
+  }
+
+  if (includes.length === 0) {
+    return
+  }
+
+  const allowIncludes = workspace.getConfiguration('mjml').get<boolean>('allowIncludes', false)
+
+  if (!allowIncludes) {
+    window.showWarningMessage(
+      `This file contains ${includes.length} mj-include tag(s) but include processing is disabled. ` +
+        `Enable 'mjml.allowIncludes' in settings to process them.`,
+    )
+    return
+  }
+
+  if (!mjmlPath) {
+    return
+  }
+
+  const coveredPaths = getIncludePath(mjmlPath) ?? []
+  const fileDir = dirname(mjmlPath)
+  const uncovered: string[] = []
+
+  for (const inc of includes) {
+    const resolvedPath = isAbsolute(inc) ? inc : joinPath(fileDir, inc)
+    const resolvedDir = dirname(resolvedPath)
+
+    // Covered if resolvedDir is the same as or inside the file's own directory
+    const relToFileDir = relative(fileDir, resolvedDir)
+    if (!relToFileDir.startsWith('..') && !isAbsolute(relToFileDir)) {
+      continue
+    }
+
+    // Covered if resolvedDir is under any allowlisted includePath entry
+    const covered = coveredPaths.some((ip) => {
+      const rel = relative(ip, resolvedDir)
+      return !rel.startsWith('..') && !isAbsolute(rel)
+    })
+
+    if (!covered) {
+      uncovered.push(inc)
+    }
+  }
+
+  if (uncovered.length > 0) {
+    window.showInformationMessage(
+      `${uncovered.length} mj-include path(s) may be outside the allowed directories. ` +
+        `Add their parent folders to 'mjml.includePath': ${uncovered.join(', ')}`,
+    )
+  }
+}
+
 export async function renderMJML(
   cb: (content: string) => any,
   fixImg?: boolean,
@@ -159,6 +219,8 @@ export async function renderMJML(
     window.showWarningMessage('This is not a MJML document!')
     return
   }
+
+  warnAboutIncludes(activeTextEditor.document.getText(), activeTextEditor.document.uri.fsPath)
 
   const result = await mjmlToHtml(
     activeTextEditor.document.getText(),

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -145,6 +145,25 @@ function encodeImage(filePath: string, original: string): string {
 }
 
 export function warnAboutIncludes(mjmlContent: string, mjmlPath?: string): void {
+  const allowIncludes = workspace.getConfiguration('mjml').get<boolean>('allowIncludes', false)
+
+  if (!allowIncludes) {
+    const includeTagCount = (mjmlContent.match(/<mj-include\b/gi) ?? []).length
+    if (includeTagCount === 0) {
+      return
+    }
+
+    window.showWarningMessage(
+      `This file contains ${includeTagCount} mj-include tag(s) but include processing is disabled. ` +
+        `Enable 'mjml.allowIncludes' in settings to process them.`,
+    )
+    return
+  }
+
+  if (!mjmlPath) {
+    return
+  }
+
   const includeRegex = /<mj-include\s+[^>]*path=["']([^"']+)["']/g
   const includes: string[] = []
   let match: RegExpExecArray | null
@@ -154,20 +173,6 @@ export function warnAboutIncludes(mjmlContent: string, mjmlPath?: string): void 
   }
 
   if (includes.length === 0) {
-    return
-  }
-
-  const allowIncludes = workspace.getConfiguration('mjml').get<boolean>('allowIncludes', false)
-
-  if (!allowIncludes) {
-    window.showWarningMessage(
-      `This file contains ${includes.length} mj-include tag(s) but include processing is disabled. ` +
-        `Enable 'mjml.allowIncludes' in settings to process them.`,
-    )
-    return
-  }
-
-  if (!mjmlPath) {
     return
   }
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -11,7 +11,7 @@ import {
   window,
   workspace,
 } from 'vscode'
-import { fixImages, isMJMLFile, mjmlToHtml } from './helper'
+import { fixImages, isMJMLFile, mjmlToHtml, warnAboutIncludes } from './helper'
 
 export default class Preview {
   private openedDocuments: TextDocument[] = []
@@ -25,6 +25,10 @@ export default class Preview {
     this.subscriptions.push(
       commands.registerCommand('mjml.previewToSide', () => {
         if (window.activeTextEditor) {
+          warnAboutIncludes(
+            window.activeTextEditor.document.getText(),
+            window.activeTextEditor.document.uri.fsPath,
+          )
           this.previewOpen = true
           this.displayWebView(window.activeTextEditor.document)
         } else {


### PR DESCRIPTION
## What's changed

### BREAKING CHANGE
- mj-include processing is now opt-in by default via `mjml.allowIncludes` settings


### Overview

The MJML 5.1.0 update addressed CVE-2025-67898 (arbitrary file inclusion vulnerability) by flipping ignoreIncludes default from false to true. This extension now aligns with MJML's secure-by-default model.

### Feature
- Added `mjml.includePath` setting (array of strings, default: `[]`) allowlist specific directories for external includes
- added warnings for when:
  -  a user performs any action that involves HTML compilation in cases where a user has added an mj-include tag but not set allowIncludes to true
  - additional warning if the user has added an mj-include with a path outside of the filepath and hasn't added that path to the includePath settings

### Fix
- Added `mjml.allowIncludes` setting (boolean, default: `false`) enables `mj-include` processing; disabled by default for security

### Chore
- Upgraded mjml version from 5.1.0 to 5.2.0

### Documentation
- Updated docs with comprehensive settings documentation

