### PR TITLE
fix(security,email): bump mjml, resolve audit issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,11 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "mjml.allowIncludes": true,
+    "mjml.includePath": [
+        "examples/includes/resources/templates"
+    ],
+    "mjml.mailer": "mailjet",
+    "mjml.lintWhenTyping": false // we want to use the TS server from our node_modules folder to control its version
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "vscode-mjml",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-mjml",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^3.0.4",
         "dotenv": "^17.4.2",
         "mime": "^4.1.0",
-        "mjml": "^5.3.0",
+        "mjml": "^5.4.0",
         "node-mailjet": "^6.0.11",
-        "nodemailer": "^8.0.9",
+        "nodemailer": "^9.0.1",
         "prettier": "^3.3.3"
       },
       "devDependencies": {
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/@colordx/core": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
-      "integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
+      "integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1651,9 +1651,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1754,9 +1754,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1773,10 +1773,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2136,9 +2136,9 @@
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -2664,9 +2664,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.363",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.363.tgz",
-      "integrity": "sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA==",
+      "version": "1.5.381",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
+      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -2962,16 +2962,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3227,9 +3227,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3811,13 +3811,10 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
-      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3826,9 +3823,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4379,69 +4386,69 @@
       }
     },
     "node_modules/mjml": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml/-/mjml-5.3.0.tgz",
-      "integrity": "sha512-cOrV1zC8SekUpZ2YGT174iWADRnuttYMtrAypQ1UvYXOUCOUc1DvwB8Dx8DH9+51+WyA0fNVOmUDx1Bc8qztqQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml/-/mjml-5.4.0.tgz",
+      "integrity": "sha512-nKeUbKsNtSLzqKcmOwGh3ELxLYHY1fdeSNLif+A33uQV4zBdHahNL7LLshvpTpG2yyu5LlZHQWogVs1dS/V30w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "mjml-cli": "5.3.0",
-        "mjml-core": "5.3.0",
-        "mjml-preset-core": "5.3.0",
-        "mjml-validator": "5.3.0"
+        "mjml-cli": "5.4.0",
+        "mjml-core": "5.4.0",
+        "mjml-preset-core": "5.4.0",
+        "mjml-validator": "5.4.0"
       },
       "bin": {
         "mjml": "bin/mjml"
       }
     },
     "node_modules/mjml-accordion": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-5.3.0.tgz",
-      "integrity": "sha512-e+tIc3rFYrPIry1JXbfQI28Z7wYiktiRbThVttfvjlTc9lXF1SCR+CnPa8V4OEyVDPq7S4oOM2fPUdRZdCmbxw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-5.4.0.tgz",
+      "integrity": "sha512-yElB+84k5kZpTz8Ct3eRu63fkEeGc4mBZmbAfZrS5sZCb9DiamAfhozLee5WgO4Y3cwuf8cFsfhYGPuBw60XCw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-body": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-5.3.0.tgz",
-      "integrity": "sha512-KWskHWzwOoCr6YpVohflqtAm/jySDqtJ0a1KmQ2MjVl8kQ15xzvothBfKmUhuHk0il1aGYcRzRcRGLtO5AmPpw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-5.4.0.tgz",
+      "integrity": "sha512-fPZLONKnRGR2NxkmfKPvnnr/ycVeyahi1ySX6Rk8lEO76ywXNFDWzTbzz/UQ2gzfnD8AhDbuqzd/UZRpW0vdOg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-button": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-5.3.0.tgz",
-      "integrity": "sha512-gu+atNP/2zXphB8ZfynJHQ+xwTcvGydd4KHCLcvGa9xH6S/pzb+FGxRjfDDUAB4fMrXniYZjU5WO+Jd59jrCow==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-5.4.0.tgz",
+      "integrity": "sha512-HlecSMeio6xf21nh4vMaHIJF8bN24KatK3gwcR6ByxKfzTkQVR7jtWjJLUiyiuLOJcam9wCOVl7m5J6elrFpjg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-carousel": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-5.3.0.tgz",
-      "integrity": "sha512-7j14yzaLbCYSUy8zcOxfrP+cEdI0Aw8vvpgGLe0S8+ieUo2vTuIsNata5fWBYS4n0MuwBywLRjbvHhd4B1X7UA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-5.4.0.tgz",
+      "integrity": "sha512-fuhOEETPC/+ZtISh5iOlc6uQqOKWwhwg1W8XTJrzWj5pfa46BzMdR7Nx0Z+8I8/HRqrZA3Ws4hiSTTgbpTIRjg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-cli": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-5.3.0.tgz",
-      "integrity": "sha512-eU0PObwnVPMVJRlwOuR/uLTqfHyjjGk5eVBKYfiZeTiah3kJ1CTQ0gDPzc2gOijrHhOIkkpTXv2XaJ60OjZSWQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-5.4.0.tgz",
+      "integrity": "sha512-6HeOz0zadc9iOmMVg85ts1HhoW2CiLUNaTFfnC5YXfowPnjK0bWfMluDzxHcaAk12wlnDF06kROl8pKpZeiy6A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -4449,10 +4456,10 @@
         "glob": "^11.1.0",
         "lodash": "^4.17.21",
         "minimatch": "^10.2.5",
-        "mjml-core": "5.3.0",
-        "mjml-parser-xml": "5.3.0",
-        "mjml-preset-core": "5.3.0",
-        "mjml-validator": "5.3.0",
+        "mjml-core": "5.4.0",
+        "mjml-parser-xml": "5.4.0",
+        "mjml-preset-core": "5.4.0",
+        "mjml-validator": "5.4.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4469,9 +4476,9 @@
       }
     },
     "node_modules/mjml-cli/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4496,20 +4503,20 @@
       }
     },
     "node_modules/mjml-column": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-5.3.0.tgz",
-      "integrity": "sha512-UUgssdrKXBdXMs/Aw41chpAqmI+bFd91nStLhKeSAyag4tcWNZ896EI8wzT36L6aFUUWbOCyo8LMzvm0KFLA2A==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-5.4.0.tgz",
+      "integrity": "sha512-vnseCiUUKhtQXx5ZEoApxA3elu2AZZyyQkOhE2ntG5cPQuZd3EhRv/mkKKCS99Vi51Tcf7AQ3chwSD4AL+bDHg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-core": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-5.3.0.tgz",
-      "integrity": "sha512-wQwj4ZQEr5SjPXIuE58fDNzQNi8zyK6b93B4r4rrB1DknvkGGbbTbzNxroVPu519czdKytxj5CF19ILcJ5K7hw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-5.4.0.tgz",
+      "integrity": "sha512-dhcbpBmxktzv/tV2Gcz7BJC15fKEP8LzXUlEYMhi0XDsNEkhHxPGXxvhMoc020jJ9Ypjobnh1q7ow+F8Xx72jA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -4521,158 +4528,158 @@
         "js-beautify": "^1.15.4",
         "juice": "^11.0.0",
         "lodash": "^4.17.21",
-        "mjml-parser-xml": "5.3.0",
-        "mjml-validator": "5.3.0",
+        "mjml-parser-xml": "5.4.0",
+        "mjml-validator": "5.4.0",
         "postcss": "^8.5.8"
       }
     },
     "node_modules/mjml-divider": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-5.3.0.tgz",
-      "integrity": "sha512-Tu/nyvM49zBhc5vf2Bs/HMS9h3CkiVVpls57nPTTA70fXR/E7Y2g2I+Qo3EaIXX4nKsHGFfMio/9GyliyavKpA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-5.4.0.tgz",
+      "integrity": "sha512-8mk7J0tn0rX+FBO43cJkaKO3x0GCjUX4bdPI5txoh1UWyq1N6xgoEqTAR3luwR0f8juTmUXZv97GnQdRUsWtvQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-group": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-5.3.0.tgz",
-      "integrity": "sha512-pHefrfa1aXW2D+mB4YYFFdfH8K9NX4hl1JOi+Fh7jjQJVRRkf6JCUAhqnikYeiGC7QO5tA1Hbk9Uzy1Zaq7USQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-5.4.0.tgz",
+      "integrity": "sha512-gCCU0WV8Aytt68uczjId3xhsvUJ8qU1WDCL+b7I3wrI1ja5npRyXdATHM6Q2uXbm+an8Dxz5q77Ts9sodAHZIQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-head": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-5.3.0.tgz",
-      "integrity": "sha512-+oDZqm6UbAAS/R1YN4zTBaR5bLcF09GmfI46e4gb/Iqbr8I13E2OxVyT1NlXEHHGldQ3JrwbPFtHn5c7nCCYpQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-5.4.0.tgz",
+      "integrity": "sha512-npWsul6ANzgxl2AZP0kG1yn9G5tOoX8iCgMhRwJkbIJ2rEX91SUvim9P/75s7HuqhccVsjO2L3OVHmnUEpWYng==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-head-attributes": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-5.3.0.tgz",
-      "integrity": "sha512-780nMvEqltEt87p9Uctqwt+YaP2EEpu+pKIDu6zpVF/7dfzKeZ5fv5Fx1FCCpi+mQaCxtJFi5ZRxUoHR+vA40Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-5.4.0.tgz",
+      "integrity": "sha512-c2/Zi/2wCutEVChxY8RGbPIb2Wb0Ro3A9WVJ0DezyEeN9noTT1fRiMWYQIc2y3H5STfNtIFu6RbtDU+AK2p4rg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-head-breakpoint": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-5.3.0.tgz",
-      "integrity": "sha512-9H9OZ5WqP5wguK4a8E+hIWvAT99G9DuyZFJspPqDHLO2D1ayTrw/Sa7TIE2DDUtNZV95vASOLKzKvbDfPK6nSw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-5.4.0.tgz",
+      "integrity": "sha512-qtJZ7uaMxVObrr13um5tbktxih8ycTStYAdcKMdSsgqLG3dTNEfVF9wg7AEHs6e3GB1cPnHgQwF9v7nxe+vocw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-head-font": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-5.3.0.tgz",
-      "integrity": "sha512-vlCL2jsMo/XtOv7I9m56Tqkz3Tkj9KFYiw2G6g7fHx8QImEeYfmWFKoGGL0xWcTvkUGFxqNLcoq1Z1Y/1lGZfQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-5.4.0.tgz",
+      "integrity": "sha512-c0shDE+Bt7tob9NNpNOk8pRpJMWztfgNuoyXAIkOc7VhILnsYzH5+4Ly70wlHOzQAspC3cODdkZxut8i3ApRcQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-head-html-attributes": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-5.3.0.tgz",
-      "integrity": "sha512-wXBMmzjgbdS71VFAXiqiYBOkp5vpP1RNOyaki0yB8Jr3E9PuKV3Qxvdm3nW1XCnGv2mpmfq+ErxxpL4qquBATQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-5.4.0.tgz",
+      "integrity": "sha512-o9yEfrA1/5r3EbxXXUVBKf91wSh+vxBSNDYQFc0Do8/8gLg7MvczFVXH2Gq9PQdxPEO+AeBrP4sGP5ZxGJnSwg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-head-preview": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-5.3.0.tgz",
-      "integrity": "sha512-7YfGqN9wHsK9d+TQBsbnfokfuQyR0m08/yUdJdiKb4pTmJenMr3Co1BhPwLwytU0oXOSgu1SuffOreDrWEffZQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-5.4.0.tgz",
+      "integrity": "sha512-jXbbRIGPn7IiAq6M/KZpQMX+RjRN9dW4Az4QTyqL4PObqsrn+rbug6vdZXdxXnCERUZiA7a7K3R4Z5BTOi+qFw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-head-style": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-5.3.0.tgz",
-      "integrity": "sha512-HYIRukcuJ7hecKIto1i3/ICT4DdyBHdfHuqXYRAp3svEsvZcNnKlOhNd/tLwYuoJTC7Cj7DoFXEKRowSDMqKkg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-5.4.0.tgz",
+      "integrity": "sha512-wUPT4G8GjHlcy0Zq67taYT0E65pa6gwSxO43VJfjpU8Qa1QNmFYkOuDkzbb9oZN0QsETmbfG/RPK/mS4uOAfsg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-head-title": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-5.3.0.tgz",
-      "integrity": "sha512-lIdVyHqsED6eakXVcpJ8zMmmWMzfi371fa1NkfpA5glL1tBpsWX7OepPPeNppADLtLWzpDYzuQ11UGEwFB12Yw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-5.4.0.tgz",
+      "integrity": "sha512-Tx4a6/CPDapUwq8NjGqfb3xBrzMXCxo3s1IGnd1Fnohl0uAZ5EySeBFf8c0uNSwrEhCDOTC5qrERm890Yselfw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-hero": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-5.3.0.tgz",
-      "integrity": "sha512-v8dRNJ5oKWsU4hXwEN/ZAEIRfhX6aN//5tvKQu0y0UQ7hfU74mFg0Op3+Y35lKTHBjoocXSZoura99mEGTLb5w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-5.4.0.tgz",
+      "integrity": "sha512-j9bKjilTHqJMp3GIDtKUdP3JRnktAc0o7gHhv1NgThgv/z1DDQJ2zgtW/pme6wA5VWng5DTriPk9aoCLPuOlyQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-image": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-5.3.0.tgz",
-      "integrity": "sha512-XdG+oKm1ThIikrX0f4+qw1GTabRfslG6tL3/Z8jj8lT50+yI3WwRw5myxZ05n35o3L+pcKeBUBv3g4aCe5rOSw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-5.4.0.tgz",
+      "integrity": "sha512-6Y8aMIZbzIZ7SSpo0/o4n5E+JQx5d7OCwUoIIiXWPWGevfOE8JvjFt5MIa24CmSDbKWbhVuJEi1h4TUJhvAVbQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-navbar": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-5.3.0.tgz",
-      "integrity": "sha512-v84TqSY1MreDBJjRjkwI1HPJuzx3HjtAWDk5kskUzJJKNIQ8cw6UGsk/V3qEq376hSyzyrxifVGODwSQ0YPnOA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-5.4.0.tgz",
+      "integrity": "sha512-knEsmNN6uBLtEU3a9uwnRqUqAE38EeJcXYaGlI0ly75Zj+vyhKQGPjJzRN7XJqA2dFSgIm3dV9KU9vNW+jI3Zg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-parser-xml": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-5.3.0.tgz",
-      "integrity": "sha512-ForLO8vZnHkQb6fdlJta52q6sSt9YW+ixP2XuQipP/FIpC4ibcwTn/lBQoIkmJJf7TZ2473qNHylwBuES5aiVw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-5.4.0.tgz",
+      "integrity": "sha512-A+KzRx+AeWIWxYN9z2KungvmVKMdW+NGLc5h+B9DeY93lSvcSpWH26nGDW9pcPi9B3fdwgYvqgOkYtX6EQATCA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -4682,124 +4689,124 @@
       }
     },
     "node_modules/mjml-preset-core": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-5.3.0.tgz",
-      "integrity": "sha512-MmCOIqhA1i1MFsO4mE3tAbPq/Oessxf4aVuUKT+izSaW/D43oRCRiQpA8dhNS9DjKHYfJ5i11uJWnC8lOShadw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-5.4.0.tgz",
+      "integrity": "sha512-rq22rNFCp4brsSAgpKrY4tXR/ZWeJeU/GyypihrzmDVu3dSFmOYbrJgW1eCo4g5rWMpEbnY8pn0t1SB8EB+ymQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "mjml-accordion": "5.3.0",
-        "mjml-body": "5.3.0",
-        "mjml-button": "5.3.0",
-        "mjml-carousel": "5.3.0",
-        "mjml-column": "5.3.0",
-        "mjml-divider": "5.3.0",
-        "mjml-group": "5.3.0",
-        "mjml-head": "5.3.0",
-        "mjml-head-attributes": "5.3.0",
-        "mjml-head-breakpoint": "5.3.0",
-        "mjml-head-font": "5.3.0",
-        "mjml-head-html-attributes": "5.3.0",
-        "mjml-head-preview": "5.3.0",
-        "mjml-head-style": "5.3.0",
-        "mjml-head-title": "5.3.0",
-        "mjml-hero": "5.3.0",
-        "mjml-image": "5.3.0",
-        "mjml-navbar": "5.3.0",
-        "mjml-raw": "5.3.0",
-        "mjml-section": "5.3.0",
-        "mjml-social": "5.3.0",
-        "mjml-spacer": "5.3.0",
-        "mjml-table": "5.3.0",
-        "mjml-text": "5.3.0",
-        "mjml-wrapper": "5.3.0"
+        "mjml-accordion": "5.4.0",
+        "mjml-body": "5.4.0",
+        "mjml-button": "5.4.0",
+        "mjml-carousel": "5.4.0",
+        "mjml-column": "5.4.0",
+        "mjml-divider": "5.4.0",
+        "mjml-group": "5.4.0",
+        "mjml-head": "5.4.0",
+        "mjml-head-attributes": "5.4.0",
+        "mjml-head-breakpoint": "5.4.0",
+        "mjml-head-font": "5.4.0",
+        "mjml-head-html-attributes": "5.4.0",
+        "mjml-head-preview": "5.4.0",
+        "mjml-head-style": "5.4.0",
+        "mjml-head-title": "5.4.0",
+        "mjml-hero": "5.4.0",
+        "mjml-image": "5.4.0",
+        "mjml-navbar": "5.4.0",
+        "mjml-raw": "5.4.0",
+        "mjml-section": "5.4.0",
+        "mjml-social": "5.4.0",
+        "mjml-spacer": "5.4.0",
+        "mjml-table": "5.4.0",
+        "mjml-text": "5.4.0",
+        "mjml-wrapper": "5.4.0"
       }
     },
     "node_modules/mjml-raw": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-5.3.0.tgz",
-      "integrity": "sha512-EpS5FkLzZ+d0OjkxZxSrTM+B17Ut2PfVAl8eQXl9R8HpD2AS3EB7D24QIPwlvSjMDEJyuMk4T4CpHTN13rcG6g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-5.4.0.tgz",
+      "integrity": "sha512-ewGXtauxkE35Xd9cJ3REjfD6vNSU82HfIm2pPi2RZF9eXrmfuSrrbSpXuPy13BP2lPpDJa6umUAuDsg5XhXr4A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-section": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-5.3.0.tgz",
-      "integrity": "sha512-U7ninyDqNIWWdPNHYLYkO94KBSubu1mjRoBJ/AoxxykvGBvAzo57rYNiVBlOUkdT0pW/1RWvEsTfE0m7vQWK1w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-5.4.0.tgz",
+      "integrity": "sha512-BetZqHS31bK5FS7rr5HlFo24m5OGDZi3yjkSn0aanF1SgRkmX1+LwnMQoDdT986SMys0oUYFeNSlz9lp8QgtrA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-social": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-5.3.0.tgz",
-      "integrity": "sha512-EbCJOhJLkC3DMKUb7H2ejYanMhjhLldtAUCuYsmAOLa8DDML4ZmtnMH/qYSVJh+Og+sUXCvXdkntujdAREzw4A==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-5.4.0.tgz",
+      "integrity": "sha512-7LUoIAOUzXzkLWfdErGrrqc8isxmDxaYQPcUNubQ1d9IXR48/S7Pi5s6PEiDxlaIgWHBcAJEoMszpLHA8+oCSQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-spacer": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-5.3.0.tgz",
-      "integrity": "sha512-DfAfysqOMhi0uFJsogrlDXk5HhakVyxQpoLSisFKB9W19v0JIwsqeCxiKXa1rz6bMakc5xcAbP82YSHwHK5SPA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-5.4.0.tgz",
+      "integrity": "sha512-v7P6InD4u7nyXTmNjKMOY0oQ2EaZzFzCcftexb6JdcqvFaZvO9vUSoOdfZUp2FzzFcXQaD7K5RRW3stJSdEJOQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-table": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-5.3.0.tgz",
-      "integrity": "sha512-ciDuuFviQH/YMisTQJZONzFBm3eSAV0EL7aCQGX203MTeYEbEta4zOxFo7aTU9EK7Tt6nfavUHKuqccKOXiuGw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-5.4.0.tgz",
+      "integrity": "sha512-e1Kq3AWzzVFv6rPgAy4eK1txA4rfMPivaavW9BrvCDJU3Wiz+fOo9FqtMDyUQXrsJJKSOi6MMA0h2lAESTsR5w==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-text": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-5.3.0.tgz",
-      "integrity": "sha512-TDlNTDt00oKMZIPYHOh9ExIc+CNPaOgNXwcoQVLtBUIhEsncBY68a1TruoaOEhu6/g1tMDML5WMueu3I5tFbpA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-5.4.0.tgz",
+      "integrity": "sha512-QTLdNM6Fs6T4LlquEzJmM+i3lJ+toNmRLRSZyUXP1tjJQhlNmc9aT1UHRy1Gn5fb7XTAY4lo2LznVv/0Tb3qhw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0"
+        "mjml-core": "5.4.0"
       }
     },
     "node_modules/mjml-validator": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-5.3.0.tgz",
-      "integrity": "sha512-0f6qfsl7cYCb69Z4T2bN9zigCluqpqLN9tATHEuHJ41GBy+Oq9ELru+yBSF+4j7rBMRQSR5Zww1Cy0TW6wxdNw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-5.4.0.tgz",
+      "integrity": "sha512-IVsV3RxiEFfAed9U0C5DYmQA06e1JWDQQ8MqBinU7lQCYUkZIexTStohDACzHpN6RTIawi+U0GkT6PUHprv+3Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       }
     },
     "node_modules/mjml-wrapper": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-5.3.0.tgz",
-      "integrity": "sha512-EDwtXvExXbBAeCT4v50iVkA8Fzdy1OCbaAZ3SKTG3oqUTU7GRB9T16fkoeBdxB/aGUQBznyol7rrvrDSrPt5FA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-5.4.0.tgz",
+      "integrity": "sha512-niCuz5T7IfLKIKVv6G4BNu6sW07yl/kJ0o8oovd+CfG4lO9K+tXUwJQ+Iv3Y3tEQp0TfJE0aN1ysGrhAz6aB6Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.3.0",
-        "mjml-section": "5.3.0"
+        "mjml-core": "5.4.0",
+        "mjml-section": "5.4.0"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -4824,9 +4831,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -4887,9 +4894,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4910,9 +4917,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.9.tgz",
-      "integrity": "sha512-5ofa7BUN8+C+Hckh5V2GjeeOGRQBx0CJQA6KxrvuZfC8iU4/q7sLn8XrtEEhJkjV6HdyIiQs7Bba6bTao8JhkA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -5310,9 +5317,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5720,9 +5727,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -7048,9 +7055,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -7375,9 +7382,9 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-mjml",
   "displayName": "MJML Official",
   "description": "MJML preview, lint, compile for Visual Studio Code.",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "publisher": "mjmlio",
   "license": "MIT",
   "readme": "README.md",
@@ -314,9 +314,14 @@
     "@types/mime": "^3.0.4",
     "dotenv": "^17.4.2",
     "mime": "^4.1.0",
-    "mjml": "^5.3.0",
+    "mjml": "^5.4.0",
     "node-mailjet": "^6.0.11",
-    "nodemailer": "^8.0.9",
+    "nodemailer": "^9.0.1",
     "prettier": "^3.3.3"
+  },
+  "overrides": {
+    "form-data": "4.0.6",
+    "js-yaml": "4.3.0",
+    "undici": "6.27.0"
   }
 }

--- a/src/email.ts
+++ b/src/email.ts
@@ -148,9 +148,29 @@ export default class Email {
 
     const recipientList: Array<{ Email: string }> = recipients
       .split(',')
-      .map((emailAddress: string) => {
-        return { Email: emailAddress.trim() }
-      })
+      .map((emailAddress: string) => emailAddress.trim())
+      .filter((emailAddress: string) => emailAddress.length > 0)
+      .map((emailAddress: string) => ({ Email: emailAddress }))
+
+    const from: { Email: string; Name?: string } = { Email: sender }
+    if (typeof fromName === 'string' && fromName.trim().length > 0) {
+      from.Name = fromName
+    }
+
+    const inlinedAttachments = attachments
+      .map((att) => ({
+        ContentType: att['Content-type'] || 'application/octet-stream',
+        Filename: att.Filename,
+        Base64Content: att.content,
+        ContentID: att.Filename,
+      }))
+      .filter(
+        (att) =>
+          typeof att.Filename === 'string' &&
+          att.Filename.length > 0 &&
+          typeof att.Base64Content === 'string' &&
+          att.Base64Content.length > 0,
+      )
 
     try {
       await mailjetClient
@@ -158,15 +178,11 @@ export default class Email {
         .request({
           Messages: [
             {
-              From: { Email: sender, Name: fromName },
+              From: from,
               To: recipientList,
               Subject: subject,
               HTMLPart: html,
-              Attachments: attachments.map((att) => ({
-                'Content-Type': att['Content-type'],
-                Filename: att.Filename,
-                'Base64Content': att.content,
-              })),
+              InlinedAttachments: inlinedAttachments,
             },
           ],
         })
@@ -207,7 +223,7 @@ export default class Email {
             })
           } else {
             attachments.push({
-              'Content-type': mime.getType(filePath),
+              'Content-type': mime.getType(filePath) || 'application/octet-stream',
               Filename: i + '_' + basename(filePath),
               content: readFileSync(filePath).toString('base64'),
               originalPath: imgPaths[i],

--- a/typings/extension.d.ts
+++ b/typings/extension.d.ts
@@ -15,6 +15,7 @@ declare interface Templates {
 }
 
 declare interface Attachments {
+  ContentType?: string
   'Content-type'?: string | null
   cid?: string
   content?: any


### PR DESCRIPTION
## What's changed

### Chore
- bumped extension version to `3.0.4`
- bumped `nodemailer` from `8.0.9` to `9.0.1`
- bumped `mjml` from `5.3.0` to `5.4.0`
- added overrides for` js-yaml` to `4.3.0`, `undici` `6.27.0`, and `form-data` `4.0.6`

### Fix
- hardened Mailjet send flow to resolve errors following `form-data` resolution
  - sanitised recipients and From name
  - send images as InlinedAttachments with valid Mailjet fields
  - default attachment content type to application/octet-stream

- update attachment typings for ContentType